### PR TITLE
feat: implement mixed order splitting and payment tracking

### DIFF
--- a/app/Http/Controllers/CustomOrderController.php
+++ b/app/Http/Controllers/CustomOrderController.php
@@ -48,6 +48,7 @@ class CustomOrderController extends Controller
             'order_type' => Order::TYPE_CUSTOM,
             'status' => Order::STATUS_PENDING,
             'total_amount' => 0, // Will be set after review
+            'payment_status' => 'unpaid',
         ]);
 
         // Create custom order

--- a/app/Http/Controllers/Customer/OrderController.php
+++ b/app/Http/Controllers/Customer/OrderController.php
@@ -11,10 +11,11 @@ class OrderController extends Controller
     public function index()
     {
         $user = Auth::user();
-		$orders = Order::with('items.item.photos')
+		$orders = Order::with('items.item.photos', 'childOrders')
 			->select('orders.*') // ensure unique orders even if future joins/filters are added
 			->distinct()
             ->where('user_id', $user->id)
+            ->whereNull('parent_order_id') // Only fetch parent or standalone orders
             ->latest()
             ->paginate(12)
             ->withQueryString();

--- a/app/Http/Controllers/Employee/CustomOrderController.php
+++ b/app/Http/Controllers/Employee/CustomOrderController.php
@@ -73,6 +73,9 @@ class CustomOrderController extends Controller
 			// Awaiting customer payment
 			$customOrder->order->status = Order::STATUS_PENDING;
 			$customOrder->order->total_amount = $customOrder->price_estimate ?? $customOrder->order->total_amount;
+			$customOrder->order->required_payment_amount = ($customOrder->price_estimate ?? $customOrder->order->total_amount) * 0.5;
+			$customOrder->order->remaining_balance = ($customOrder->price_estimate ?? $customOrder->order->total_amount) * 0.5;
+			$customOrder->order->payment_status = 'unpaid';
 			$customOrder->order->save();
 		}
 

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -7,6 +7,7 @@ use App\Models\Payment;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 
 class PaymentController extends Controller
 {
@@ -30,39 +31,119 @@ class PaymentController extends Controller
 			return response()->json(['success' => false, 'message' => 'Unauthorized'], 403);
 		}
 
+		// Validate payment amount against required payment
+		$paymentAmount = (float) $validated['amount'];
+		$requiredAmount = (float) ($order->required_payment_amount ?? $order->total_amount);
+		
+		if ($paymentAmount < $requiredAmount) {
+			return response()->json([
+				'success' => false,
+				'message' => "Payment amount ₱" . number_format($paymentAmount, 2) . " is below the required amount of ₱" . number_format($requiredAmount, 2)
+			], 422);
+		}
+
 		try {
-			$payment = Payment::create([
-				'order_id' => $order->id,
-				'method' => 'gcash',
-				'amount' => $validated['amount'],
-				'status' => 'paid',
-				'transaction_id' => $validated['reference'],
-			]);
-
-			// Mirror to order for compatibility and mark as paid
-			$order->payment_method = 'GCash';
-			$order->payment_status = 'paid';
-			
-			// If order is still pending or waiting for payment, move to processing/backorder
-			if ($order->status === 'pending') {
-				// Determine appropriate status based on order type
-				if ($order->order_type === Order::TYPE_BACKORDER) {
-					$order->status = Order::STATUS_BACKORDER;
-				} else {
-					$order->status = Order::STATUS_PROCESSING;
+			$results = DB::transaction(function () use ($order, $paymentAmount, $validated) {
+				$createdPayments = [];
+				$reference = $validated['reference'];
+				// If this is a parent mixed order, allocate payment to children in order (standard first)
+				if ($order->order_type === 'mixed' && $order->childOrders()->exists()) {
+					$remaining = $paymentAmount;
+					// Load children and prefer standard before backorder
+					$children = $order->childOrders()->get()->sortByDesc(function ($c) {
+						return $c->order_type === 'standard' ? 1 : 0;
+					});
+					foreach ($children as $child) {
+						$childRequired = (float) ($child->required_payment_amount ?? $child->total_amount * $child->getRequiredPaymentPercentage());
+						if ($remaining <= 0) {
+							// no money left to allocate
+							continue;
+						}
+						if ($remaining >= $childRequired) {
+							// fully pay this child
+							$payAmount = $childRequired;
+							$createdPayments[] = Payment::create([
+								'order_id' => $child->id,
+								'method' => 'gcash',
+								'amount' => $payAmount,
+								'status' => 'paid',
+								'transaction_id' => $reference,
+							]);
+							$child->payment_method = 'GCash';
+							$child->payment_status = 'paid';
+							$child->remaining_balance = 0;
+							$child->save();
+							$remaining -= $payAmount;
+						} else {
+							// partial payment for this child
+							$payAmount = $remaining;
+							$createdPayments[] = Payment::create([
+								'order_id' => $child->id,
+								'method' => 'gcash',
+								'amount' => $payAmount,
+								'status' => 'paid',
+								'transaction_id' => $reference,
+							]);
+							$child->payment_method = 'GCash';
+							$child->payment_status = 'partially_paid';
+							$child->remaining_balance = max(0, $childRequired - $payAmount);
+							$child->save();
+							$remaining = 0;
+						}
+					}
+					// Update parent aggregate
+					$parentRemaining = $order->childOrders()->sum('remaining_balance');
+					$order->payment_method = 'GCash';
+					$order->remaining_balance = $parentRemaining;
+					$order->payment_status = $parentRemaining <= 0 ? 'paid' : 'partially_paid';
+					$order->status = $order->payment_status === 'paid' ? Order::STATUS_PROCESSING : Order::STATUS_BACKORDER;
+					$order->save();
+					return $createdPayments;
 				}
-			}
-			
-			$order->save();
-
-			// If this is a custom order awaiting payment, move to in_production
-			if ($order->customOrders && $order->customOrders()->where('status', 'approved')->exists()) {
-				$order->customOrders()->where('status', 'approved')->update(['status' => 'in_production']);
-				$order->status = Order::STATUS_PROCESSING;
+				// Non-parent (single) order handling
+				$payment = Payment::create([
+					'order_id' => $order->id,
+					'method' => 'gcash',
+					'amount' => $paymentAmount,
+					'status' => 'paid',
+					'transaction_id' => $validated['reference'],
+				]);
+				$createdPayments[] = $payment;
+				// decide order payment status based on required payment amount
+				$orderTotal = (float) $order->total_amount;
+				$orderRequired = (float) ($order->required_payment_amount ?? $orderTotal);
+				// For backorder/custom: remaining balance is based on FULL total, not required amount
+				$remainingBalance = max(0, $orderTotal - $orderRequired); // The remaining portion after down payment
+				
+				if ($paymentAmount >= $orderTotal) {
+					// Paid everything
+					$order->payment_status = 'paid';
+					$order->remaining_balance = 0;
+					$order->status = Order::STATUS_PROCESSING;
+				} else {
+					// Partial payment (at this point, validation ensures $paymentAmount >= $orderRequired)
+					$order->payment_status = 'partially_paid';
+					$order->remaining_balance = $remainingBalance;
+					$order->status = Order::STATUS_BACKORDER;
+				}
+				$order->payment_method = 'GCash';
 				$order->save();
-			}
+				// If this is a child order, update siblings/parent appropriately
+				if ($order->parent_order_id) {
+					$parent = Order::find($order->parent_order_id);
+					if ($parent) {
+						$parentRemaining = $parent->childOrders()->sum('remaining_balance');
+						$parent->remaining_balance = $parentRemaining;
+						$parent->payment_status = $parentRemaining <= 0 ? 'paid' : 'partially_paid';
+						$parent->payment_method = 'GCash';
+						$parent->status = $parent->payment_status === 'paid' ? Order::STATUS_PROCESSING : Order::STATUS_BACKORDER;
+						$parent->save();
+					}
+				}
+				return $createdPayments;
+			});
 
-			return response()->json(['success' => true, 'payment' => $payment]);
+			return response()->json(['success' => true, 'payments' => $results]);
 		} catch (\Exception $e) {
 			return response()->json(['success' => false, 'message' => 'Payment processing failed: ' . $e->getMessage()], 500);
 		}
@@ -88,27 +169,66 @@ class PaymentController extends Controller
 			return response()->json(['success' => false, 'message' => 'Unauthorized'], 403);
 		}
 
+		// Validate payment amount against required payment
+		$paymentAmount = (float) $validated['amount'];
+		$requiredAmount = (float) ($order->required_payment_amount ?? $order->total_amount);
+		
+		if ($paymentAmount < $requiredAmount) {
+			return response()->json([
+				'success' => false,
+				'message' => "Payment amount ₱" . number_format($paymentAmount, 2) . " is below the required amount of ₱" . number_format($requiredAmount, 2)
+			], 422);
+		}
+
 		try {
-			$path = $request->file('proof')->store('bank-proofs', 'public');
+			$results = DB::transaction(function () use ($order, $paymentAmount, $request) {
+				$path = $request->file('proof')->store('bank-proofs', 'public');
+				$createdPayments = [];
+				// If parent mixed order, allocate pending payments to children
+				if ($order->order_type === 'mixed' && $order->childOrders()->exists()) {
+					$remaining = $paymentAmount;
+					$children = $order->childOrders()->get()->sortByDesc(function ($c) {
+						return $c->order_type === 'standard' ? 1 : 0;
+					});
+					foreach ($children as $child) {
+						$childRequired = (float) ($child->required_payment_amount ?? $child->total_amount * $child->getRequiredPaymentPercentage());
+						if ($remaining <= 0) continue;
+						$alloc = min($remaining, $childRequired);
+						$createdPayments[] = Payment::create([
+							'order_id' => $child->id,
+							'method' => 'bank',
+							'amount' => $alloc,
+							'status' => 'pending_verification',
+							'proof_image' => $path,
+						]);
+						// leave child.order payment_status as unpaid until verification, but store a tentative remaining_balance
+						$child->remaining_balance = max(0, $childRequired - $alloc);
+						$child->payment_method = 'Bank Transfer';
+						$child->save();
+						$remaining -= $alloc;
+					}
+					// parent stays unpaid awaiting verification, but record aggregate values
+					$order->payment_method = 'Bank Transfer';
+					$order->save();
+					return ['payments' => $createdPayments, 'path' => $path];
+				}
+				// Single order path
+				$path = $request->file('proof')->store('bank-proofs', 'public');
+				$payment = Payment::create([
+					'order_id' => $order->id,
+					'method' => 'bank',
+					'amount' => $paymentAmount,
+					'status' => 'pending_verification',
+					'proof_image' => $path,
+				]);
+				$order->payment_method = 'Bank Transfer';
+				// keep unpaid until admin verifies
+				$order->payment_status = 'unpaid';
+				$order->save();
+				return ['payments' => [$payment], 'path' => $path];
+			});
 
-			$payment = Payment::create([
-				'order_id' => $order->id,
-				'method' => 'bank',
-				'amount' => $validated['amount'],
-				'status' => 'pending_verification',
-				'proof_image' => $path,
-			]);
-
-			$order->payment_method = 'Bank Transfer';
-			// Keep payment_status as unpaid until admin verifies the bank transfer
-			$order->payment_status = 'unpaid';
-			
-			// Bank transfer requires verification, but we'll mark as awaiting verification
-			// Admin will verify and update status to 'paid' after which order processing begins
-			
-			$order->save();
-
-			return response()->json(['success' => true, 'payment' => $payment, 'proof_url' => Storage::url($path)]);
+			return response()->json(['success' => true, 'result' => $results, 'proof_url' => Storage::url($results['path'])]);
 		} catch (\Exception $e) {
 			return response()->json(['success' => false, 'message' => 'Upload failed: ' . $e->getMessage()], 500);
 		}

--- a/database/migrations/2025_11_13_000001_add_payment_tracking_to_orders_table.php
+++ b/database/migrations/2025_11_13_000001_add_payment_tracking_to_orders_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            // Add columns for partial payment tracking
+            if (!Schema::hasColumn('orders', 'required_payment_amount')) {
+                $table->decimal('required_payment_amount', 10, 2)->nullable()->default(null)->comment('Amount customer must pay at checkout');
+            }
+            if (!Schema::hasColumn('orders', 'remaining_balance')) {
+                $table->decimal('remaining_balance', 10, 2)->nullable()->default(null)->comment('Remaining balance for partial payments');
+            }
+            // Update payment_status enum to include 'partially_paid'
+            $table->comment = 'Orders table with payment tracking for standard, backorder, and custom orders';
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropColumn(['required_payment_amount', 'remaining_balance']);
+        });
+    }
+};

--- a/database/migrations/2025_11_13_000002_update_payment_status_enum.php
+++ b/database/migrations/2025_11_13_000002_update_payment_status_enum.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Update payment_status enum values to include 'partially_paid'
+        Schema::table('orders', function (Blueprint $table) {
+            // For MySQL compatibility - we'll change the enum to include partial_paid
+            // For SQLite, we need to handle this differently
+            $driver = DB::getDriverName();
+            
+            if ($driver === 'mysql') {
+                DB::statement("ALTER TABLE orders MODIFY payment_status ENUM('unpaid', 'partially_paid', 'paid', 'refunded') DEFAULT 'unpaid'");
+            }
+            // SQLite doesn't support ALTER ENUM, so we'll handle it in the model validation
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $driver = DB::getDriverName();
+            if ($driver === 'mysql') {
+                DB::statement("ALTER TABLE orders MODIFY payment_status ENUM('unpaid', 'paid', 'refunded') DEFAULT 'unpaid'");
+            }
+        });
+    }
+};

--- a/database/migrations/2025_11_13_000003_add_parent_order_id_to_orders_table.php
+++ b/database/migrations/2025_11_13_000003_add_parent_order_id_to_orders_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            // Add parent_order_id for mixed orders parent-child relationships
+            if (!Schema::hasColumn('orders', 'parent_order_id')) {
+                $table->foreignId('parent_order_id')
+                    ->nullable()
+                    ->after('user_id')
+                    ->constrained('orders')
+                    ->cascadeOnDelete()
+                    ->comment('Reference to parent order for mixed order splitting');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            if (Schema::hasColumn('orders', 'parent_order_id')) {
+                $table->dropForeignKeyIfExists(['parent_order_id']);
+                $table->dropColumn('parent_order_id');
+            }
+        });
+    }
+};

--- a/database/migrations/2025_11_13_000004_add_mixed_to_order_type_enum.php
+++ b/database/migrations/2025_11_13_000004_add_mixed_to_order_type_enum.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Add 'mixed' to order_type enum
+        $driver = DB::getDriverName();
+        
+        if ($driver === 'mysql') {
+            DB::statement("ALTER TABLE orders MODIFY order_type ENUM('standard', 'backorder', 'preorder', 'custom', 'mixed') NOT NULL");
+        }
+        // SQLite doesn't support direct enum modifications, handled in model validation
+    }
+
+    public function down(): void
+    {
+        $driver = DB::getDriverName();
+        
+        if ($driver === 'mysql') {
+            DB::statement("ALTER TABLE orders MODIFY order_type ENUM('standard', 'backorder', 'preorder', 'custom') NOT NULL");
+        }
+    }
+};

--- a/resources/views/customer-orders.blade.php
+++ b/resources/views/customer-orders.blade.php
@@ -62,13 +62,88 @@
         @endif
 
 		@php
-			$standardOrders = $orders->filter(fn($o) => ($o->order_type ?? '') === 'standard');
-			$backOrdersOrders = $orders->filter(fn($o) => ($o->order_type ?? '') === 'backorder');
+			// Separate parent orders (mixed orders) from regular orders
+			$parentOrders = $orders->filter(fn($o) => ($o->order_type ?? '') === 'mixed' && !$o->parent_order_id);
+			$regularOrders = $orders->filter(fn($o) => ($o->order_type ?? '') !== 'mixed' && !$o->parent_order_id);
+			$standardOrders = $regularOrders->filter(fn($o) => ($o->order_type ?? '') === 'standard');
+			$backOrdersOrders = $regularOrders->filter(fn($o) => ($o->order_type ?? '') === 'backorder');
+			
 			$firstPhoto = function($order){
 				$firstItem = optional($order->items)->first();
 				return optional(optional($firstItem)->item?->photos?->first())->url;
 			};
+			
+			$getStatusColor = function($status) {
+				return match($status) {
+					'pending' => 'bg-yellow-100 text-yellow-800',
+					'processing', 'ready_to_ship', 'ready_for_delivery' => 'bg-blue-100 text-blue-800',
+					'shipped', 'in_production' => 'bg-indigo-100 text-indigo-800',
+					'delivered', 'completed' => 'bg-green-100 text-green-800',
+					'cancelled' => 'bg-red-100 text-red-800',
+					'backorder' => 'bg-orange-100 text-orange-800',
+					default => 'bg-gray-100 text-gray-800',
+				};
+			};
 		@endphp
+
+		<!-- Mixed Orders (Parent Orders) Section -->
+		@if($parentOrders->isNotEmpty())
+			<div class="mb-6 bg-white border border-purple-100 rounded-xl shadow-sm p-4">
+				<h2 class="text-lg font-medium text-gray-900">Your Mixed Orders</h2>
+				<p class="text-sm text-purple-700 mt-1">Orders containing both standard and back order items.</p>
+				<div class="mt-3 divide-y">
+					@foreach($parentOrders as $parentOrder)
+						<div class="py-4">
+							<!-- Parent Order Header -->
+							<div class="flex items-center justify-between mb-3">
+								<div class="flex items-center gap-3 flex-1">
+									@if($firstPhoto($parentOrder))
+										<img src="{{ $firstPhoto($parentOrder) }}" class="w-12 h-12 rounded object-cover bg-gray-100"/>
+									@else
+										<div class="w-12 h-12 rounded bg-gray-100 flex items-center justify-center text-gray-400">
+											<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+											</svg>
+										</div>
+									@endif
+									<div class="flex-1">
+										<div class="font-medium text-gray-900">Mixed Order #{{ $parentOrder->id }}</div>
+										<div class="text-xs text-gray-500">Placed: {{ $parentOrder->created_at?->format('M d, Y') }}</div>
+										<div class="text-xs text-purple-700 font-medium">Total: ₱{{ number_format($parentOrder->total_amount, 2) }} • Payment: {{ $parentOrder->getPaymentStatusLabel() }}</div>
+									</div>
+								</div>
+								<div class="flex flex-col items-end gap-2">
+									<span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ $getStatusColor($parentOrder->status) }}">
+										{{ ucfirst($parentOrder->status) }}
+									</span>
+									<a href="{{ route('customer.orders.show', $parentOrder->id) }}" class="text-xs text-purple-700 hover:underline">View Details</a>
+								</div>
+							</div>
+							
+							<!-- Child Orders (Sub-Orders) -->
+							@php $childOrders = $parentOrder->childOrders; @endphp
+							@if($childOrders->isNotEmpty())
+								<div class="ml-4 border-l-2 border-purple-200 pl-4 space-y-2">
+									@foreach($childOrders as $childOrder)
+										<div class="py-2 flex items-center justify-between bg-purple-50 px-3 rounded">
+											<div class="flex-1">
+												<div class="text-sm font-medium text-gray-900">
+													{{ ucfirst($childOrder->order_type) }} Sub-Order #{{ $childOrder->id }}
+												</div>
+												<div class="text-xs text-gray-600">
+													Amount: ₱{{ number_format($childOrder->total_amount, 2) }} • Status: {{ ucfirst($childOrder->status) }}
+												</div>
+											</div>
+											<a href="{{ route('customer.orders.show', $childOrder->id) }}" class="text-xs text-purple-600 hover:underline">View</a>
+										</div>
+									@endforeach
+								</div>
+							@endif
+						</div>
+					@endforeach
+				</div>
+			</div>
+		@endif
 
 		@if($standardOrders->isNotEmpty())
 			<div class="mb-6 bg-white border border-gray-100 rounded-xl shadow-sm p-4">
@@ -139,7 +214,7 @@
 			</div>
 		@endif
 
-		@if($standardOrders->isEmpty() && $backOrdersOrders->isEmpty() && (empty($customOrders) || $customOrders->isEmpty()))
+		@if($parentOrders->isEmpty() && $standardOrders->isEmpty() && $backOrdersOrders->isEmpty() && (empty($customOrders) || $customOrders->isEmpty()))
 			<div class="px-4 py-6 bg-white border border-gray-100 rounded-xl shadow-sm text-center text-gray-500">No orders yet.</div>
 		@endif
     </section>

--- a/resources/views/employee/orders.blade.php
+++ b/resources/views/employee/orders.blade.php
@@ -125,16 +125,25 @@
             </div>
             <div>
                 @forelse($orders as $o)
-                    <div class="grid grid-cols-12 items-center px-4 py-4 border-b text-sm hover:bg-gray-50/50">
+                    <!-- Order Row -->
+                    <div class="grid grid-cols-12 items-center px-4 py-4 border-b text-sm hover:bg-gray-50/50 {{ $o->order_type === 'mixed' ? 'bg-purple-50' : '' }}">
                         <div class="col-span-12 md:col-span-2">
-                            #{{ $o->id }}
+                            {{ $o->order_type === 'mixed' ? '📦' : '' }} #{{ $o->id }}
+                            @if($o->order_type === 'mixed' && $o->childOrders->isNotEmpty())
+                                <div class="text-xs text-purple-700 mt-1">{{ $o->childOrders->count() }} sub-orders</div>
+                            @endif
                         </div>
                         <div class="col-span-12 md:col-span-2 mt-2 md:mt-0">
                             <div class="font-medium text-gray-900 truncate">{{ $o->user->name ?? 'Guest' }}</div>
                             <div class="text-xs text-gray-500 truncate">{{ $o->user->email ?? '' }}</div>
                         </div>
                         <div class="col-span-6 md:col-span-1 mt-2 md:mt-0">
-                            <span class="inline-flex px-2 py-0.5 rounded text-xs border @if($o->order_type === 'standard') border-green-300 bg-green-50 text-green-700 @elseif($o->order_type === 'backorder') border-blue-300 bg-blue-50 text-blue-700 @else border-gray-300 bg-white @endif">
+                            <span class="inline-flex px-2 py-0.5 rounded text-xs border 
+                                @if($o->order_type === 'standard') border-green-300 bg-green-50 text-green-700
+                                @elseif($o->order_type === 'backorder') border-blue-300 bg-blue-50 text-blue-700
+                                @elseif($o->order_type === 'mixed') border-purple-300 bg-purple-50 text-purple-700
+                                @else border-gray-300 bg-white 
+                                @endif">
                                 @if($o->order_type === 'standard')
                                     Standard
                                 @elseif($o->order_type === 'backorder')
@@ -161,16 +170,21 @@
                                 $paymentStatus = $o->payment_status ?? 'unpaid';
                                 $paymentColor = [
                                     'paid' => 'bg-green-100 text-green-800',
+                                    'partially_paid' => 'bg-blue-100 text-blue-800',
                                     'unpaid' => 'bg-red-100 text-red-800',
                                     'pending_verification' => 'bg-yellow-100 text-yellow-800',
                                 ][$paymentStatus] ?? 'bg-gray-100 text-gray-700';
                                 $paymentLabel = [
-                                    'paid' => 'Paid ✓',
+                                    'paid' => 'Fully Paid ✓',
+                                    'partially_paid' => 'Partially Paid',
                                     'unpaid' => 'Unpaid',
-                                    'pending_verification' => 'Pending',
+                                    'pending_verification' => 'Pending Verification',
                                 ][$paymentStatus] ?? ucfirst($paymentStatus);
                             @endphp
                             <span class="inline-flex px-2 py-0.5 rounded text-xs {{ $paymentColor }}">{{ $paymentLabel }}</span>
+                            @if($paymentStatus === 'partially_paid' && ($o->remaining_balance ?? 0) > 0)
+                                <div class="text-xs text-blue-700 mt-1 font-semibold">Remaining: ₱{{ number_format($o->remaining_balance, 2) }}</div>
+                            @endif
                         </div>
                         <div class="col-span-6 md:col-span-2 mt-2 md:mt-0 text-gray-600">{{ $o->created_at->format('M d, Y') }}</div>
                         <div class="col-span-6 md:col-span-1 mt-2 md:mt-0 font-medium">₱{{ number_format($o->total_amount ?? 0, 2) }}</div>
@@ -178,6 +192,52 @@
                             <a href="{{ route('employee.orders.show', $o->id) }}" class="inline-flex items-center px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 text-xs font-medium">View</a>
                         </div>
                     </div>
+                    
+                    <!-- Sub-Orders Row (if mixed order) -->
+                    @if($o->order_type === 'mixed' && $o->childOrders->isNotEmpty())
+                        @foreach($o->childOrders as $childOrder)
+                            <div class="grid grid-cols-12 items-center px-4 py-3 border-b bg-purple-25 text-sm">
+                                <div class="col-span-12 md:col-span-2 pl-8 text-gray-600">
+                                    └─ Sub-Order #{{ $childOrder->id }}
+                                </div>
+                                <div class="col-span-12 md:col-span-2 mt-2 md:mt-0">
+                                    <div class="text-xs text-gray-600">{{ ucfirst($childOrder->order_type) }} Items</div>
+                                </div>
+                                <div class="col-span-6 md:col-span-1 mt-2 md:mt-0">
+                                    <span class="inline-flex px-2 py-0.5 rounded text-xs border 
+                                        @if($childOrder->order_type === 'standard') border-green-300 bg-green-50 text-green-700
+                                        @else border-blue-300 bg-blue-50 text-blue-700
+                                        @endif">
+                                        {{ ucfirst($childOrder->order_type) }}
+                                    </span>
+                                </div>
+                                <div class="col-span-6 md:col-span-1 mt-2 md:mt-0">
+                                    @php
+                                        $childStatusColor = $statusColor ?? 'bg-gray-100 text-gray-700';
+                                    @endphp
+                                    <span class="inline-flex px-2 py-0.5 rounded text-xs capitalize {{ $childStatusColor }}">{{ $childOrder->status }}</span>
+                                </div>
+                                <div class="col-span-6 md:col-span-1 mt-2 md:mt-0">
+                                    <span class="inline-flex px-2 py-0.5 rounded text-xs 
+                                        @php
+                                            $childPaymentStatus = $childOrder->payment_status ?? 'unpaid';
+                                            echo match($childPaymentStatus) {
+                                                'paid' => 'bg-green-100 text-green-800',
+                                                'partially_paid' => 'bg-blue-100 text-blue-800',
+                                                default => 'bg-red-100 text-red-800'
+                                            };
+                                        @endphp">
+                                        {{ ucfirst($childPaymentStatus) }}
+                                    </span>
+                                </div>
+                                <div class="col-span-6 md:col-span-2 mt-2 md:mt-0"></div>
+                                <div class="col-span-6 md:col-span-1 mt-2 md:mt-0 font-medium text-purple-700">₱{{ number_format($childOrder->total_amount ?? 0, 2) }}</div>
+                                <div class="col-span-6 md:col-span-1 mt-2 md:mt-0 text-right">
+                                    <a href="{{ route('employee.orders.show', $childOrder->id) }}" class="inline-flex items-center px-3 py-1.5 rounded-lg border border-purple-300 text-purple-700 hover:bg-purple-50 text-xs font-medium">View</a>
+                                </div>
+                            </div>
+                        @endforeach
+                    @endif
                 @empty
                     <div class="px-4 py-10 text-center text-gray-600">No orders found.</div>
                 @endforelse

--- a/resources/views/order-confirmation.blade.php
+++ b/resources/views/order-confirmation.blade.php
@@ -36,12 +36,44 @@ body{font-family:'Poppins','Inter',ui-sans-serif,system-ui;}
                     $isCustomOrder = $order->order_type === 'custom';
                     $customOrder = $isCustomOrder ? $order->customOrders->first() : null;
 				@endphp
-				<div class="mt-2 text-sm flex flex-wrap gap-2">
+                <div class="mt-2 text-sm flex flex-wrap gap-2">
 					<span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium capitalize bg-gray-100 text-gray-800">Type: {{ $order->order_type }}</span>
 					<span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium capitalize {{ $statusColor }}">Status: {{ $order->status }}</span>
                 </div>
 
-                @if($hasBackorder)
+                <!-- Parent-Sub Order Info -->
+                @if($order->order_type === 'mixed' && $order->childOrders->isNotEmpty())
+                    <div class="mt-4 p-4 rounded-md border border-purple-200 bg-purple-50">
+                        <h3 class="font-medium text-purple-900">Mixed Order Details</h3>
+                        <p class="text-sm text-purple-800 mt-1">Your order contains both standard and back order items. They will be processed and shipped separately for efficiency.</p>
+                        <div class="mt-3 space-y-2">
+                            @foreach($order->childOrders as $child)
+                                <div class="flex items-center justify-between bg-white px-3 py-2 rounded border border-purple-100 text-sm">
+                                    <span class="font-medium text-gray-900">{{ ucfirst($child->order_type) }} Sub-Order #{{ $child->id }}</span>
+                                    <span class="text-purple-700">₱{{ number_format($child->total_amount, 2) }}</span>
+                                </div>
+                            @endforeach
+                        </div>
+                        <div class="mt-3 pt-3 border-t border-purple-200">
+                            <div class="flex items-center justify-between">
+                                <span class="font-semibold text-purple-900">Total Amount</span>
+                                <span class="text-lg font-bold text-purple-900">₱{{ number_format($order->total_amount, 2) }}</span>
+                            </div>
+                        </div>
+                    </div>
+                @elseif($order->parent_order_id)
+                    <!-- This is a sub-order -->
+                    @php $parentOrder = $order->parentOrder; @endphp
+                    <div class="mt-4 p-4 rounded-md border border-purple-200 bg-purple-50">
+                        <h3 class="font-medium text-purple-900">Part of Mixed Order</h3>
+                        <p class="text-sm text-purple-800 mt-1">This is a {{ ucfirst($order->order_type) }} sub-order from your parent mixed order.</p>
+                        <div class="mt-2 text-sm">
+                            <strong>Parent Order:</strong> #{{ $parentOrder->id }} (₱{{ number_format($parentOrder->total_amount, 2) }})
+                        </div>
+                    </div>
+                @endif
+
+                @if($hasBackorder && !$order->parent_order_id && $order->order_type !== 'mixed')
                     <div class="mt-4 p-4 rounded-md border border-blue-200 bg-blue-50">
                         <h3 class="font-medium text-blue-900">Order Status</h3>
                         <div class="mt-2 text-sm text-blue-800 space-y-1">
@@ -49,9 +81,7 @@ body{font-family:'Poppins','Inter',ui-sans-serif,system-ui;}
                             <p><strong>⏳ Back Order Items:</strong> Awaiting stock - will ship separately once restocked</p>
                         </div>
                     </div>
-                @endif
-
-                @if($isCustomOrder && $customOrder)
+                @endif                @if($isCustomOrder && $customOrder)
                     @php
                         $customStatusColor = match($customOrder->status) {
                             'pending_review' => 'bg-yellow-100 text-yellow-800',

--- a/storage/framework/views/050576902ae57f4224e82f5b8b2d4221.php
+++ b/storage/framework/views/050576902ae57f4224e82f5b8b2d4221.php
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4" style="margin-bottom: -8px;">
+  <path fill-rule="evenodd" d="M9.47 6.47a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 1 1-1.06 1.06L10 8.06l-3.72 3.72a.75.75 0 0 1-1.06-1.06l4.25-4.25Z" clip-rule="evenodd" />
+</svg>
+<?php /**PATH C:\xampp\htdocs\wowc\vendor\laravel\framework\src\Illuminate\Foundation\Providers/../resources/exceptions/renderer/components/icons/chevron-up.blade.php ENDPATH**/ ?>

--- a/storage/framework/views/1906f9e3fc398c4ab265d63e074837b9.php
+++ b/storage/framework/views/1906f9e3fc398c4ab265d63e074837b9.php
@@ -1,0 +1,60 @@
+<?php use \Illuminate\Foundation\Exceptions\Renderer\Renderer; ?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1"
+    />
+
+    <title><?php echo e(config('app.name', 'Laravel')); ?></title>
+
+    <link rel="icon" type="image/svg+xml"
+          href="data:image/svg+xml,%3Csvg viewBox='0 -.11376601 49.74245785 51.31690859' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m49.626 11.564a.809.809 0 0 1 .028.209v10.972a.8.8 0 0 1 -.402.694l-9.209 5.302v10.509c0 .286-.152.55-.4.694l-19.223 11.066c-.044.025-.092.041-.14.058-.018.006-.035.017-.054.022a.805.805 0 0 1 -.41 0c-.022-.006-.042-.018-.063-.026-.044-.016-.09-.03-.132-.054l-19.219-11.066a.801.801 0 0 1 -.402-.694v-32.916c0-.072.01-.142.028-.21.006-.023.02-.044.028-.067.015-.042.029-.085.051-.124.015-.026.037-.047.055-.071.023-.032.044-.065.071-.093.023-.023.053-.04.079-.06.029-.024.055-.05.088-.069h.001l9.61-5.533a.802.802 0 0 1 .8 0l9.61 5.533h.002c.032.02.059.045.088.068.026.02.055.038.078.06.028.029.048.062.072.094.017.024.04.045.054.071.023.04.036.082.052.124.008.023.022.044.028.068a.809.809 0 0 1 .028.209v20.559l8.008-4.611v-10.51c0-.07.01-.141.028-.208.007-.024.02-.045.028-.068.016-.042.03-.085.052-.124.015-.026.037-.047.054-.071.024-.032.044-.065.072-.093.023-.023.052-.04.078-.06.03-.024.056-.05.088-.069h.001l9.611-5.533a.801.801 0 0 1 .8 0l9.61 5.533c.034.02.06.045.09.068.025.02.054.038.077.06.028.029.048.062.072.094.018.024.04.045.054.071.023.039.036.082.052.124.009.023.022.044.028.068zm-1.574 10.718v-9.124l-3.363 1.936-4.646 2.675v9.124l8.01-4.611zm-9.61 16.505v-9.13l-4.57 2.61-13.05 7.448v9.216zm-36.84-31.068v31.068l17.618 10.143v-9.214l-9.204-5.209-.003-.002-.004-.002c-.031-.018-.057-.044-.086-.066-.025-.02-.054-.036-.076-.058l-.002-.003c-.026-.025-.044-.056-.066-.084-.02-.027-.044-.05-.06-.078l-.001-.003c-.018-.03-.029-.066-.042-.1-.013-.03-.03-.058-.038-.09v-.001c-.01-.038-.012-.078-.016-.117-.004-.03-.012-.06-.012-.09v-21.483l-4.645-2.676-3.363-1.934zm8.81-5.994-8.007 4.609 8.005 4.609 8.006-4.61-8.006-4.608zm4.164 28.764 4.645-2.674v-20.096l-3.363 1.936-4.646 2.675v20.096zm24.667-23.325-8.006 4.609 8.006 4.609 8.005-4.61zm-.801 10.605-4.646-2.675-3.363-1.936v9.124l4.645 2.674 3.364 1.937zm-18.422 20.561 11.743-6.704 5.87-3.35-8-4.606-9.211 5.303-8.395 4.833z' fill='%23ff2d20'/%3E%3C/svg%3E" />
+
+    <link
+        href="https://fonts.bunny.net/css?family=figtree:300,400,500,600"
+        rel="stylesheet"
+    />
+
+    <?php echo Renderer::css(); ?>
+
+
+    <style>
+        <?php $__currentLoopData = $exception->frames(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $frame): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+            #frame-<?php echo e($loop->index); ?> .hljs-ln-line[data-line-number='<?php echo e($frame->line()); ?>'] {
+                background-color: rgba(242, 95, 95, 0.4);
+            }
+        <?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
+    </style>
+</head>
+<body class="bg-gray-200/80 font-sans antialiased dark:bg-gray-950/95">
+    <?php echo e($slot); ?>
+
+
+    <?php echo Renderer::js(); ?>
+
+
+    <script>
+        !function(r,o){"use strict";var e,i="hljs-ln",l="hljs-ln-line",h="hljs-ln-code",s="hljs-ln-numbers",c="hljs-ln-n",m="data-line-number",a=/\r\n|\r|\n/g;function u(e){for(var n=e.toString(),t=e.anchorNode;"TD"!==t.nodeName;)t=t.parentNode;for(var r=e.focusNode;"TD"!==r.nodeName;)r=r.parentNode;var o=parseInt(t.dataset.lineNumber),a=parseInt(r.dataset.lineNumber);if(o==a)return n;var i,l=t.textContent,s=r.textContent;for(a<o&&(i=o,o=a,a=i,i=l,l=s,s=i);0!==n.indexOf(l);)l=l.slice(1);for(;-1===n.lastIndexOf(s);)s=s.slice(0,-1);for(var c=l,u=function(e){for(var n=e;"TABLE"!==n.nodeName;)n=n.parentNode;return n}(t),d=o+1;d<a;++d){var f=p('.{0}[{1}="{2}"]',[h,m,d]);c+="\n"+u.querySelector(f).textContent}return c+="\n"+s}function n(e){try{var n=o.querySelectorAll("code.hljs,code.nohighlight");for(var t in n)n.hasOwnProperty(t)&&(n[t].classList.contains("nohljsln")||d(n[t],e))}catch(e){r.console.error("LineNumbers error: ",e)}}function d(e,n){"object"==typeof e&&r.setTimeout(function(){e.innerHTML=f(e,n)},0)}function f(e,n){var t,r,o=(t=e,{singleLine:function(e){return!!e.singleLine&&e.singleLine}(r=(r=n)||{}),startFrom:function(e,n){var t=1;isFinite(n.startFrom)&&(t=n.startFrom);var r=function(e,n){return e.hasAttribute(n)?e.getAttribute(n):null}(e,"data-ln-start-from");return null!==r&&(t=function(e,n){if(!e)return n;var t=Number(e);return isFinite(t)?t:n}(r,1)),t}(t,r)});return function e(n){var t=n.childNodes;for(var r in t){var o;t.hasOwnProperty(r)&&(o=t[r],0<(o.textContent.trim().match(a)||[]).length&&(0<o.childNodes.length?e(o):v(o.parentNode)))}}(e),function(e,n){var t=g(e);""===t[t.length-1].trim()&&t.pop();if(1<t.length||n.singleLine){for(var r="",o=0,a=t.length;o<a;o++)r+=p('<tr><td class="{0} {1}" {3}="{5}"><div class="{2}" {3}="{5}"></div></td><td class="{0} {4}" {3}="{5}">{6}</td></tr>',[l,s,c,m,h,o+n.startFrom,0<t[o].length?t[o]:" "]);return p('<table class="{0}">{1}</table>',[i,r])}return e}(e.innerHTML,o)}function v(e){var n=e.className;if(/hljs-/.test(n)){for(var t=g(e.innerHTML),r=0,o="";r<t.length;r++){o+=p('<span class="{0}">{1}</span>\n',[n,0<t[r].length?t[r]:" "])}e.innerHTML=o.trim()}}function g(e){return 0===e.length?[]:e.split(a)}function p(e,t){return e.replace(/\{(\d+)\}/g,function(e,n){return void 0!==t[n]?t[n]:e})}r.hljs?(r.hljs.initLineNumbersOnLoad=function(e){"interactive"===o.readyState||"complete"===o.readyState?n(e):r.addEventListener("DOMContentLoaded",function(){n(e)})},r.hljs.lineNumbersBlock=d,r.hljs.lineNumbersValue=function(e,n){if("string"!=typeof e)return;var t=document.createElement("code");return t.innerHTML=e,f(t,n)},(e=o.createElement("style")).type="text/css",e.innerHTML=p(".{0}{border-collapse:collapse}.{0} td{padding:0}.{1}:before{content:attr({2})}",[i,c,m]),o.getElementsByTagName("head")[0].appendChild(e)):r.console.error("highlight.js not detected!"),document.addEventListener("copy",function(e){var n,t=window.getSelection();!function(e){for(var n=e;n;){if(n.className&&-1!==n.className.indexOf("hljs-ln-code"))return 1;n=n.parentNode}}(t.anchorNode)||(n=-1!==window.navigator.userAgent.indexOf("Edge")?u(t):t.toString(),e.clipboardData.setData("text/plain",n),e.preventDefault())})}(window,document);
+
+        hljs.initLineNumbersOnLoad()
+
+        window.addEventListener('load', function() {
+            document.querySelectorAll('.renderer').forEach(function(element, index) {
+                if (index > 0) {
+                    element.remove();
+                }
+            });
+
+            document.querySelector('.default-highlightable-code').style.display = 'block';
+
+            document.querySelectorAll('.highlightable-code').forEach(function(element) {
+                element.style.display = 'block';
+            })
+        });
+    </script>
+</body>
+</html>
+<?php /**PATH C:\xampp\htdocs\wowc\vendor\laravel\framework\src\Illuminate\Foundation\Providers/../resources/exceptions/renderer/components/layout.blade.php ENDPATH**/ ?>

--- a/storage/framework/views/1c82f280543c457aa2e52c10b84d32a8.php
+++ b/storage/framework/views/1c82f280543c457aa2e52c10b84d32a8.php
@@ -1,0 +1,27 @@
+<script>
+    let exceptionAsMarkdown = <?php echo e(Illuminate\Support\Js::from($markdown)); ?>
+
+</script>
+<div
+    class="relative inline-block text-sm rounded-full bg-white px-3 py-2 dark:bg-gray-800 sm:col-span-1 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer transition-colors duration-200 ease-in-out"
+    x-data="{
+        copied: false,
+        copy() {
+            const textarea = document.createElement('textarea');
+            textarea.value = exceptionAsMarkdown;
+            textarea.style.position = 'absolute';
+            textarea.style.left = '-9999px';
+            document.body.appendChild(textarea);
+            textarea.select();
+            document.execCommand('copy');
+            document.body.removeChild(textarea);
+
+            this.copied = true;
+            setTimeout(() => this.copied = false, 1000);
+        }
+    }"
+    @click="copy"
+>
+    <span x-text="copied ? 'Copied to clipboard' : 'Copy as Markdown'"></span>
+</div>
+<?php /**PATH C:\xampp\htdocs\wowc\vendor\laravel\framework\src\Illuminate\Foundation\Providers/../resources/exceptions/renderer/components/copy-button.blade.php ENDPATH**/ ?>

--- a/storage/framework/views/239cc6754ecb82173204bc632b73299f.php
+++ b/storage/framework/views/239cc6754ecb82173204bc632b73299f.php
@@ -1,0 +1,8 @@
+<section
+    <?php echo e($attributes->merge(['class' => "@container flex flex-col p-6 sm:p-12 bg-white dark:bg-gray-900/80 text-gray-900 dark:text-gray-100 rounded-lg default:col-span-full default:lg:col-span-6 default:row-span-1 dark:ring-1 dark:ring-gray-800 shadow-xl"])); ?>
+
+>
+    <?php echo e($slot); ?>
+
+</section>
+<?php /**PATH C:\xampp\htdocs\wowc\vendor\laravel\framework\src\Illuminate\Foundation\Providers/../resources/exceptions/renderer/components/card.blade.php ENDPATH**/ ?>

--- a/storage/framework/views/29faf5bea8aba4b7871dedde85fac454.php
+++ b/storage/framework/views/29faf5bea8aba4b7871dedde85fac454.php
@@ -1,0 +1,202 @@
+<?php if (isset($component)) { $__componentOriginal69dc84650370d1d4dc1b42d016d7226b = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal69dc84650370d1d4dc1b42d016d7226b = $attributes; } ?>
+<?php $component = App\View\Components\GuestLayout::resolve([] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('guest-layout'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\App\View\Components\GuestLayout::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes([]); ?>
+    <div class="min-h-screen w-full flex flex-col lg:flex-row">
+
+        <!-- ========== LEFT PANEL (Image + Message) ========== -->
+        <div class="w-full lg:w-1/2 hidden lg:flex items-center justify-center bg-cover bg-center relative"
+             style="background-image: url('<?php echo e(asset('images/login-bg.jpg')); ?>');">
+
+            <div class="absolute inset-0 bg-[#A9793E] bg-opacity-50"></div>
+
+            <div class="relative z-10 text-white text-center px-10">
+                <h2 class="text-4xl font-bold mb-4">Join WOW Carmen</h2>
+                <p class="text-white text-opacity-90">
+                    Create an account to explore our handcrafted products.
+                </p>
+            </div>
+        </div>
+
+        <!-- ========== RIGHT PANEL (Register Form) ========== -->
+        <div class="w-full lg:w-1/2 flex items-center justify-center px-6 py-12">
+            <div class="w-full max-w-md space-y-6">
+
+                <h2 class="text-3xl font-semibold text-[#1F1F1F]">Create Account</h2>
+
+                <form method="POST" action="<?php echo e(route('register')); ?>" class="space-y-5">
+                    <?php echo csrf_field(); ?>
+
+                    <!-- Name Fields -->
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                        <!-- First Name -->
+                        <div>
+                            <label for="first_name" class="block text-sm font-medium text-gray-700">First Name</label>
+                            <input id="first_name" type="text" name="first_name" value="<?php echo e(old('first_name')); ?>" required autofocus
+                                   class="w-full px-4 py-3 border rounded-full shadow-sm focus:ring-[#A9793E] focus:border-[#A9793E]"
+                                   placeholder="First Name">
+                            <?php $__errorArgs = ['first_name'];
+$__bag = $errors->getBag($__errorArgs[1] ?? 'default');
+if ($__bag->has($__errorArgs[0])) :
+if (isset($message)) { $__messageOriginal = $message; }
+$message = $__bag->first($__errorArgs[0]); ?>
+                                <p class="text-red-500 text-sm mt-1"><?php echo e($message); ?></p>
+                            <?php unset($message);
+if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+endif;
+unset($__errorArgs, $__bag); ?>
+                        </div>
+                        <!-- Last Name -->
+                        <div>
+                            <label for="last_name" class="block text-sm font-medium text-gray-700">Last Name</label>
+                            <input id="last_name" type="text" name="last_name" value="<?php echo e(old('last_name')); ?>" required
+                                   class="w-full px-4 py-3 border rounded-full shadow-sm focus:ring-[#A9793E] focus:border-[#A9793E]"
+                                   placeholder="Last Name">
+                            <?php $__errorArgs = ['last_name'];
+$__bag = $errors->getBag($__errorArgs[1] ?? 'default');
+if ($__bag->has($__errorArgs[0])) :
+if (isset($message)) { $__messageOriginal = $message; }
+$message = $__bag->first($__errorArgs[0]); ?>
+                                <p class="text-red-500 text-sm mt-1"><?php echo e($message); ?></p>
+                            <?php unset($message);
+if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+endif;
+unset($__errorArgs, $__bag); ?>
+                        </div>
+                    </div>
+
+                    <!-- Address Line -->
+                    <div>
+                        <label for="address_line" class="block text-sm font-medium text-gray-700">Address</label>
+                        <input id="address_line" type="text" name="address_line" value="<?php echo e(old('address_line')); ?>" required
+                               class="w-full px-4 py-3 border rounded-full shadow-sm focus:ring-[#A9793E] focus:border-[#A9793E]"
+                               placeholder="Street / Barangay">
+                        <?php $__errorArgs = ['address_line'];
+$__bag = $errors->getBag($__errorArgs[1] ?? 'default');
+if ($__bag->has($__errorArgs[0])) :
+if (isset($message)) { $__messageOriginal = $message; }
+$message = $__bag->first($__errorArgs[0]); ?>
+                            <p class="text-red-500 text-sm mt-1"><?php echo e($message); ?></p>
+                        <?php unset($message);
+if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+endif;
+unset($__errorArgs, $__bag); ?>
+                    </div>
+
+                    <!-- City / Province / Postal -->
+                    <div class="grid grid-cols-3 gap-3">
+                        <div>
+                            <label for="city" class="block text-sm font-medium text-gray-700">City</label>
+                            <input id="city" type="text" name="city" value="<?php echo e(old('city')); ?>" required
+                                   class="w-full px-4 py-3 border rounded-full shadow-sm focus:ring-[#A9793E] focus:border-[#A9793E]">
+                        </div>
+                        <div>
+                            <label for="province" class="block text-sm font-medium text-gray-700">Province</label>
+                            <input id="province" type="text" name="province" value="<?php echo e(old('province')); ?>" required
+                                   class="w-full px-4 py-3 border rounded-full shadow-sm focus:ring-[#A9793E] focus:border-[#A9793E]">
+                        </div>
+                        <div>
+                            <label for="postal_code" class="block text-sm font-medium text-gray-700">Postal Code</label>
+                            <input id="postal_code" type="text" name="postal_code" value="<?php echo e(old('postal_code')); ?>" required
+                                   class="w-full px-4 py-3 border rounded-full shadow-sm focus:ring-[#A9793E] focus:border-[#A9793E]">
+                        </div>
+                    </div>
+
+                    <!-- Contact Number (kept) -->
+                    <div>
+                        <label for="contact_number" class="block text-sm font-medium text-gray-700">Contact Number</label>
+                        <input id="contact_number" type="text" name="contact_number" value="<?php echo e(old('contact_number')); ?>" required
+                               class="w-full px-4 py-3 border rounded-full shadow-sm focus:ring-[#A9793E] focus:border-[#A9793E]"
+                               placeholder="09XXXXXXXXX or +639XXXXXXXXX">
+                        <?php $__errorArgs = ['contact_number'];
+$__bag = $errors->getBag($__errorArgs[1] ?? 'default');
+if ($__bag->has($__errorArgs[0])) :
+if (isset($message)) { $__messageOriginal = $message; }
+$message = $__bag->first($__errorArgs[0]); ?>
+                            <p class="text-red-500 text-sm mt-1"><?php echo e($message); ?></p>
+                        <?php unset($message);
+if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+endif;
+unset($__errorArgs, $__bag); ?>
+                    </div>
+
+                    <!-- Email -->
+                    <div>
+                        <label for="email" class="block text-sm font-medium text-gray-700">Email</label>
+                        <input id="email" type="email" name="email" value="<?php echo e(old('email')); ?>" required
+                               class="w-full px-4 py-3 border rounded-full shadow-sm focus:ring-[#A9793E] focus:border-[#A9793E]"
+                               placeholder="Email">
+                        <?php $__errorArgs = ['email'];
+$__bag = $errors->getBag($__errorArgs[1] ?? 'default');
+if ($__bag->has($__errorArgs[0])) :
+if (isset($message)) { $__messageOriginal = $message; }
+$message = $__bag->first($__errorArgs[0]); ?>
+                            <p class="text-red-500 text-sm mt-1"><?php echo e($message); ?></p>
+                        <?php unset($message);
+if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+endif;
+unset($__errorArgs, $__bag); ?>
+                    </div>
+
+                    <!-- Password -->
+                    <div>
+                        <label for="password" class="block text-sm font-medium text-gray-700">Password</label>
+                        <input id="password" type="password" name="password" required
+                               class="w-full px-4 py-3 border rounded-full shadow-sm focus:ring-[#A9793E] focus:border-[#A9793E]"
+                               placeholder="Password">
+                        <?php $__errorArgs = ['password'];
+$__bag = $errors->getBag($__errorArgs[1] ?? 'default');
+if ($__bag->has($__errorArgs[0])) :
+if (isset($message)) { $__messageOriginal = $message; }
+$message = $__bag->first($__errorArgs[0]); ?>
+                            <p class="text-red-500 text-sm mt-1"><?php echo e($message); ?></p>
+                        <?php unset($message);
+if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+endif;
+unset($__errorArgs, $__bag); ?>
+                    </div>
+
+                    <!-- Confirm Password -->
+                    <div>
+                        <label for="password_confirmation" class="block text-sm font-medium text-gray-700">Confirm Password</label>
+                        <input id="password_confirmation" type="password" name="password_confirmation" required
+                               class="w-full px-4 py-3 border rounded-full shadow-sm focus:ring-[#A9793E] focus:border-[#A9793E]"
+                               placeholder="Confirm Password">
+                    </div>
+
+                    <!-- Submit -->
+                    <div>
+                        <button type="submit"
+                                class="w-full py-3 bg-[#A9793E] hover:bg-[#8F6532] text-white font-semibold rounded-full transition">
+                            Register
+                        </button>
+                    </div>
+
+                    <!-- Already have an account -->
+                    <p class="text-sm text-center text-gray-600">
+                        Already have an account?
+                        <a href="<?php echo e(route('login')); ?>" class="text-[#A9793E] hover:underline">
+                            Sign In
+                        </a>
+                    </p>
+                </form>
+            </div>
+        </div>
+    </div>
+ <?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal69dc84650370d1d4dc1b42d016d7226b)): ?>
+<?php $attributes = $__attributesOriginal69dc84650370d1d4dc1b42d016d7226b; ?>
+<?php unset($__attributesOriginal69dc84650370d1d4dc1b42d016d7226b); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal69dc84650370d1d4dc1b42d016d7226b)): ?>
+<?php $component = $__componentOriginal69dc84650370d1d4dc1b42d016d7226b; ?>
+<?php unset($__componentOriginal69dc84650370d1d4dc1b42d016d7226b); ?>
+<?php endif; ?>
+<?php /**PATH C:\xampp\htdocs\wowc\resources\views/auth/register.blade.php ENDPATH**/ ?>

--- a/storage/framework/views/2b2a19ff5b1d23b27e15c7cd32dc8aae.php
+++ b/storage/framework/views/2b2a19ff5b1d23b27e15c7cd32dc8aae.php
@@ -1,0 +1,12 @@
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    <?php echo e($attributes); ?>
+
+>
+    <path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 01-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0115 18.257V17.25m6-12V15a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 15V5.25m18 0A2.25 2.25 0 0018.75 3H5.25A2.25 2.25 0 003 5.25m18 0V12a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 12V5.25" />
+</svg>
+<?php /**PATH C:\xampp\htdocs\wowc\vendor\laravel\framework\src\Illuminate\Foundation\Providers/../resources/exceptions/renderer/components/icons/computer-desktop.blade.php ENDPATH**/ ?>

--- a/storage/framework/views/2fc211fe3c06bda2ad51b2eedc92dae9.php
+++ b/storage/framework/views/2fc211fe3c06bda2ad51b2eedc92dae9.php
@@ -1,0 +1,12 @@
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    <?php echo e($attributes); ?>
+
+>
+    <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" />
+</svg>
+<?php /**PATH C:\xampp\htdocs\wowc\vendor\laravel\framework\src\Illuminate\Foundation\Providers/../resources/exceptions/renderer/components/icons/sun.blade.php ENDPATH**/ ?>

--- a/storage/framework/views/31529b84719a5b18e08ed78f9cc5afc5.php
+++ b/storage/framework/views/31529b84719a5b18e08ed78f9cc5afc5.php
@@ -1,0 +1,69 @@
+<header class="mt-3 px-5 sm:mt-10">
+    <div class="py-3 dark:border-gray-900 sm:py-5">
+        <div class="flex items-center justify-between">
+            <div class="flex items-center">
+                <div class="rounded-full bg-red-500/20 p-4 dark:bg-red-500/20">
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke-width="1.5"
+                        stroke="currentColor"
+                        class="h-6 w-6 fill-red-500 text-gray-50 dark:text-gray-950"
+                    >
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
+                    </svg>
+                </div>
+
+                <span class="text-dark ml-3 text-2xl font-bold dark:text-white sm:text-3xl">
+                    <?php echo e($exception->title()); ?>
+
+                </span>
+            </div>
+
+            <div class="flex items-center gap-3 sm:gap-6">
+                <?php if (isset($component)) { $__componentOriginala65c25d014fe95dcda324a85a3ac253a = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginala65c25d014fe95dcda324a85a3ac253a = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.copy-button','data' => ['markdown' => $exceptionAsMarkdown]] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::copy-button'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes(['markdown' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute($exceptionAsMarkdown)]); ?>
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginala65c25d014fe95dcda324a85a3ac253a)): ?>
+<?php $attributes = $__attributesOriginala65c25d014fe95dcda324a85a3ac253a; ?>
+<?php unset($__attributesOriginala65c25d014fe95dcda324a85a3ac253a); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginala65c25d014fe95dcda324a85a3ac253a)): ?>
+<?php $component = $__componentOriginala65c25d014fe95dcda324a85a3ac253a; ?>
+<?php unset($__componentOriginala65c25d014fe95dcda324a85a3ac253a); ?>
+<?php endif; ?>
+                <?php if (isset($component)) { $__componentOriginal9b6ddd2809dd60ece07dfaf1f3ef876f = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal9b6ddd2809dd60ece07dfaf1f3ef876f = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.theme-switcher','data' => []] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::theme-switcher'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes([]); ?>
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal9b6ddd2809dd60ece07dfaf1f3ef876f)): ?>
+<?php $attributes = $__attributesOriginal9b6ddd2809dd60ece07dfaf1f3ef876f; ?>
+<?php unset($__attributesOriginal9b6ddd2809dd60ece07dfaf1f3ef876f); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal9b6ddd2809dd60ece07dfaf1f3ef876f)): ?>
+<?php $component = $__componentOriginal9b6ddd2809dd60ece07dfaf1f3ef876f; ?>
+<?php unset($__componentOriginal9b6ddd2809dd60ece07dfaf1f3ef876f); ?>
+<?php endif; ?>
+            </div>
+        </div>
+    </div>
+</header>
+<?php /**PATH C:\xampp\htdocs\wowc\vendor\laravel\framework\src\Illuminate\Foundation\Providers/../resources/exceptions/renderer/components/navigation.blade.php ENDPATH**/ ?>

--- a/storage/framework/views/49b9567c9dbb694431ef486287ddada5.php
+++ b/storage/framework/views/49b9567c9dbb694431ef486287ddada5.php
@@ -1,0 +1,110 @@
+<?php if (isset($component)) { $__componentOriginalbbd4eeea836234825f7514ed20d2d52d = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginalbbd4eeea836234825f7514ed20d2d52d = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.layout','data' => ['exception' => $exception]] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::layout'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes(['exception' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute($exception)]); ?>
+    <div class="renderer container mx-auto lg:px-8">
+        <?php if (isset($component)) { $__componentOriginal10cd8b81fdad4ce00a06c99f27003014 = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal10cd8b81fdad4ce00a06c99f27003014 = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.navigation','data' => ['exception' => $exception,'exceptionAsMarkdown' => $exceptionAsMarkdown]] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::navigation'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes(['exception' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute($exception),'exceptionAsMarkdown' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute($exceptionAsMarkdown)]); ?>
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal10cd8b81fdad4ce00a06c99f27003014)): ?>
+<?php $attributes = $__attributesOriginal10cd8b81fdad4ce00a06c99f27003014; ?>
+<?php unset($__attributesOriginal10cd8b81fdad4ce00a06c99f27003014); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal10cd8b81fdad4ce00a06c99f27003014)): ?>
+<?php $component = $__componentOriginal10cd8b81fdad4ce00a06c99f27003014; ?>
+<?php unset($__componentOriginal10cd8b81fdad4ce00a06c99f27003014); ?>
+<?php endif; ?>
+
+        <main class="px-6 pb-12 pt-6">
+            <div class="container mx-auto">
+                <?php if (isset($component)) { $__componentOriginal1e817eb3c41fe3ea9eb0c15213c4b557 = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal1e817eb3c41fe3ea9eb0c15213c4b557 = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.header','data' => ['exception' => $exception]] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::header'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes(['exception' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute($exception)]); ?>
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal1e817eb3c41fe3ea9eb0c15213c4b557)): ?>
+<?php $attributes = $__attributesOriginal1e817eb3c41fe3ea9eb0c15213c4b557; ?>
+<?php unset($__attributesOriginal1e817eb3c41fe3ea9eb0c15213c4b557); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal1e817eb3c41fe3ea9eb0c15213c4b557)): ?>
+<?php $component = $__componentOriginal1e817eb3c41fe3ea9eb0c15213c4b557; ?>
+<?php unset($__componentOriginal1e817eb3c41fe3ea9eb0c15213c4b557); ?>
+<?php endif; ?>
+
+                <?php if (isset($component)) { $__componentOriginal1dc7d865c9b6045c4d68faf8bde572ed = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal1dc7d865c9b6045c4d68faf8bde572ed = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.trace-and-editor','data' => ['exception' => $exception]] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::trace-and-editor'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes(['exception' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute($exception)]); ?>
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal1dc7d865c9b6045c4d68faf8bde572ed)): ?>
+<?php $attributes = $__attributesOriginal1dc7d865c9b6045c4d68faf8bde572ed; ?>
+<?php unset($__attributesOriginal1dc7d865c9b6045c4d68faf8bde572ed); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal1dc7d865c9b6045c4d68faf8bde572ed)): ?>
+<?php $component = $__componentOriginal1dc7d865c9b6045c4d68faf8bde572ed; ?>
+<?php unset($__componentOriginal1dc7d865c9b6045c4d68faf8bde572ed); ?>
+<?php endif; ?>
+
+                <?php if (isset($component)) { $__componentOriginal523928ff754f95aea6faf87444393a04 = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal523928ff754f95aea6faf87444393a04 = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.context','data' => ['exception' => $exception]] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::context'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes(['exception' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute($exception)]); ?>
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal523928ff754f95aea6faf87444393a04)): ?>
+<?php $attributes = $__attributesOriginal523928ff754f95aea6faf87444393a04; ?>
+<?php unset($__attributesOriginal523928ff754f95aea6faf87444393a04); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal523928ff754f95aea6faf87444393a04)): ?>
+<?php $component = $__componentOriginal523928ff754f95aea6faf87444393a04; ?>
+<?php unset($__componentOriginal523928ff754f95aea6faf87444393a04); ?>
+<?php endif; ?>
+            </div>
+        </main>
+    </div>
+ <?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginalbbd4eeea836234825f7514ed20d2d52d)): ?>
+<?php $attributes = $__attributesOriginalbbd4eeea836234825f7514ed20d2d52d; ?>
+<?php unset($__attributesOriginalbbd4eeea836234825f7514ed20d2d52d); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginalbbd4eeea836234825f7514ed20d2d52d)): ?>
+<?php $component = $__componentOriginalbbd4eeea836234825f7514ed20d2d52d; ?>
+<?php unset($__componentOriginalbbd4eeea836234825f7514ed20d2d52d); ?>
+<?php endif; ?>
+<?php /**PATH C:\xampp\htdocs\wowc\vendor\laravel\framework\src\Illuminate\Foundation\Providers/../resources/exceptions/renderer/show.blade.php ENDPATH**/ ?>

--- a/storage/framework/views/51a50faf0a39a7aae306ec88c05a4365.php
+++ b/storage/framework/views/51a50faf0a39a7aae306ec88c05a4365.php
@@ -1,0 +1,12 @@
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    <?php echo e($attributes); ?>
+
+>
+    <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" />
+</svg>
+<?php /**PATH C:\xampp\htdocs\wowc\vendor\laravel\framework\src\Illuminate\Foundation\Providers/../resources/exceptions/renderer/components/icons/moon.blade.php ENDPATH**/ ?>

--- a/storage/framework/views/644a1897f5e5ae240ec1230b114040d4.php
+++ b/storage/framework/views/644a1897f5e5ae240ec1230b114040d4.php
@@ -1,0 +1,51 @@
+<?php if (isset($component)) { $__componentOriginal74daf2d0a9c625ad90327a6043d15980 = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal74daf2d0a9c625ad90327a6043d15980 = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.card','data' => []] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::card'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes([]); ?>
+    <div class="md:flex md:items-center md:justify-between md:gap-2">
+        <div class="min-w-0">
+            <div class="inline-block rounded-full bg-red-500/20 px-3 py-2 max-w-full text-sm font-bold leading-5 text-red-500 truncate lg:text-base dark:bg-red-500/20">
+                <span class="hidden md:inline">
+                    <?php echo e($exception->class()); ?>
+
+                </span>
+                <span class="md:hidden">
+                    <?php echo e(implode(' ', array_slice(explode('\\', $exception->class()), -1))); ?>
+
+                </span>
+            </div>
+            <div class="mt-4 text-lg font-semibold text-gray-900 break-words dark:text-white lg:text-2xl">
+                <?php echo e($exception->message()); ?>
+
+            </div>
+        </div>
+
+        <div class="hidden text-right shrink-0 md:block md:min-w-64 md:max-w-80">
+            <div>
+                <span class="inline-block rounded-full bg-gray-200 px-3 py-2 text-sm leading-5 text-gray-900 max-w-full truncate dark:bg-gray-800 dark:text-white">
+                    <?php echo e($exception->request()->method()); ?> <?php echo e($exception->request()->httpHost()); ?>
+
+                </span>
+            </div>
+            <div class="px-4">
+                <span class="text-sm text-gray-500 dark:text-gray-400">PHP <?php echo e(PHP_VERSION); ?> — Laravel <?php echo e(app()->version()); ?></span>
+            </div>
+        </div>
+    </div>
+ <?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal74daf2d0a9c625ad90327a6043d15980)): ?>
+<?php $attributes = $__attributesOriginal74daf2d0a9c625ad90327a6043d15980; ?>
+<?php unset($__attributesOriginal74daf2d0a9c625ad90327a6043d15980); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal74daf2d0a9c625ad90327a6043d15980)): ?>
+<?php $component = $__componentOriginal74daf2d0a9c625ad90327a6043d15980; ?>
+<?php unset($__componentOriginal74daf2d0a9c625ad90327a6043d15980); ?>
+<?php endif; ?>
+<?php /**PATH C:\xampp\htdocs\wowc\vendor\laravel\framework\src\Illuminate\Foundation\Providers/../resources/exceptions/renderer/components/header.blade.php ENDPATH**/ ?>

--- a/storage/framework/views/654881fc605fc90882cfc39f4956ebc1.php
+++ b/storage/framework/views/654881fc605fc90882cfc39f4956ebc1.php
@@ -52,10 +52,31 @@
                             <input name="phone_number" value="<?php echo e(old('phone_number', $addr->phone_number ?? '')); ?>" placeholder="Phone Number" class="sm:col-span-2 rounded-md border-gray-300" required>
                         </div>
 
-						<h3 class="mt-6 text-lg font-semibold text-gray-900">Payment</h3>
-                        <div class="mt-3 p-3 bg-blue-50 border border-blue-200 rounded-lg mb-4">
-                            <p class="text-sm text-blue-800"><strong>Important:</strong> Payment is required to complete your order. Please select a payment method below.</p>
-                        </div>
+                        <h3 class="mt-6 text-lg font-semibold text-gray-900">Payment</h3>
+                        <?php
+                            $paymentPercentage = $paymentPercentage ?? 1.0;
+                            $requiredPaymentAmount = $requiredPaymentAmount ?? $total;
+                            $isPartialPayment = $paymentPercentage < 1.0;
+                            $orderType = isset($payOrder) && $payOrder ? ($payOrder->order_type ?? 'custom') : 'standard';
+                            $isBackOrderOrCustom = $orderType === 'backorder' || $orderType === 'custom';
+                        ?>
+                        
+                        <?php if($isBackOrderOrCustom): ?>
+                            <div class="mt-3 p-4 bg-amber-50 border-2 border-amber-300 rounded-lg mb-4">
+                                <div class="flex items-start gap-3">
+                                    <span class="text-2xl">💰</span>
+                                    <div>
+                                        <p class="font-bold text-amber-900">Down Payment Required (50%)</p>
+                                        <p class="text-sm text-amber-800 mt-1">This is a <?php echo e($orderType === 'backorder' ? 'Back Order' : 'Custom Order'); ?>. You must pay <strong>50% upfront</strong> now to proceed. The remaining 50% will be due when the order is ready.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        <?php else: ?>
+                            <div class="mt-3 p-3 bg-blue-50 border border-blue-200 rounded-lg mb-4">
+                                <p class="text-sm text-blue-800"><strong>Important:</strong> Payment is required to complete your order. Please select a payment method below.</p>
+                            </div>
+                        <?php endif; ?>
+                        
                         <div class="mt-3 grid grid-cols-2 gap-3">
 							<label class="flex items-center justify-center gap-2 border rounded-md p-3 cursor-pointer hover:border-gray-400">
                                 <input type="radio" name="payment_method" value="Bank" x-model="method" class="hidden">
@@ -66,9 +87,7 @@
 								<img src="/images/gcash.png" alt="GCash" class="h-5">
 								<span class="text-sm">GCash</span>
 							</label>
-						</div>
-
-						<div class="mt-6 text-right">
+						</div>						<div class="mt-6 text-right">
 							<button id="completeBtn" type="button" class="inline-flex items-center justify-center px-6 py-3 rounded-md text-white font-medium shadow-sm hover:shadow transition" style="background:#c59d5f;">Complete Order</button>
 						</div>
 					</form>
@@ -79,74 +98,144 @@
 					<h2 class="text-lg font-semibold text-gray-900">Order Summary</h2>
                         <?php
 							$paymentOnly = isset($payOrder) && $payOrder;
-                            // Use the cart line's is_backorder flag to separate standard vs backorder
-                            $standardItems = $paymentOnly ? collect() : $cartItems->filter(fn($ci) => !($ci->is_backorder ?? false));
-                            $backOrderItems = $paymentOnly ? collect() : $cartItems->filter(fn($ci) => ($ci->is_backorder ?? false));
-                            $standardTotal = $paymentOnly ? 0 : $standardItems->sum('subtotal');
-                            $backOrderTotal = $paymentOnly ? 0 : $backOrderItems->sum('subtotal');
+                            $isMixedOrder = isset($isMixedOrder) && $isMixedOrder;
+                            $standardItems = $standardItems ?? collect();
+                            $backorderItems = $backorderItems ?? collect();
+                            $standardSubtotal = $standardSubtotal ?? 0;
+                            $backorderSubtotal = $backorderSubtotal ?? 0;
+                            $requiredPaymentAmount = $requiredPaymentAmount ?? $total;
                         ?>
 
-                        <!-- Standard Items -->
-                        <?php if(!$paymentOnly && $standardItems->isNotEmpty()): ?>
-                            <div class="mt-4">
-                                <h3 class="text-sm font-medium text-gray-900">Standard Items</h3>
-                                <div class="mt-3 space-y-4">
-                                    <?php $__currentLoopData = $standardItems; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $ci): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
-                                        <div class="flex items-center justify-between gap-4">
-                                            <div class="flex items-center gap-3">
-                                                <div class="w-16 h-16 rounded bg-gray-100 overflow-hidden">
-                                                    <img src="<?php echo e(optional($ci->item->photos->first())->url); ?>" alt="" class="w-full h-full object-cover"/>
-                                                </div>
-                                                <div>
-                                                    <p class="text-sm font-medium text-gray-900"><?php echo e($ci->item->name); ?></p>
-                                                    <p class="text-xs text-gray-500">Qty: <?php echo e($ci->quantity); ?></p>
-                                                </div>
-                                            </div>
-                                            <div class="text-right">
-                                                <p class="text-sm text-gray-900">₱<?php echo e(number_format($ci->subtotal, 2)); ?></p>
-                                            </div>
-                                        </div>
-                                    <?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
-                                </div>
-                                <?php if($backOrderItems->isNotEmpty()): ?>
-                                    <p class="mt-2 text-sm text-gray-700">Standard items subtotal: ₱<?php echo e(number_format($standardTotal, 2)); ?></p>
-                                <?php endif; ?>
-                            </div>
-                        <?php endif; ?>
-
-                        <!-- Back Order Items -->
-                        <?php if(!$paymentOnly && $backOrderItems->isNotEmpty()): ?>
-                            <div class="mt-6">
-                                <div class="mb-3 p-3 bg-blue-50 border border-blue-100 rounded-lg">
-                                    <h3 class="text-sm font-medium text-blue-800">Back Order Items</h3>
-                                    <p class="mt-1 text-xs text-blue-700">These items will be shipped separately once they're back in stock.</p>
-                                </div>
-                                <div class="space-y-4">
-                                    <?php $__currentLoopData = $backOrderItems; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $ci): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
-                                        <div class="flex items-center justify-between gap-4">
-                                            <div class="flex items-center gap-3">
-                                                <div class="w-16 h-16 rounded bg-gray-100 overflow-hidden">
-                                                    <img src="<?php echo e(optional($ci->item->photos->first())->url); ?>" alt="" class="w-full h-full object-cover"/>
-                                                </div>
-                                                <div>
-                                                    <p class="text-sm font-medium text-gray-900"><?php echo e($ci->item->name); ?></p>
-                                                    <p class="text-xs text-gray-500">Qty: <?php echo e($ci->quantity); ?></p>
-                                                    <span class="inline-flex mt-1 px-2 py-0.5 text-[11px] rounded bg-blue-100 text-blue-800">Back-Order</span>
-                                                    <?php if($ci->item->restock_date): ?>
-                                                        <span class="block text-[11px] text-blue-700">Ships after <?php echo e($ci->item->restock_date->format('M d, Y')); ?></span>
-                                                    <?php endif; ?>
-                                                </div>
-                                            </div>
-                                            <div class="text-right">
-                                                <p class="text-sm text-gray-900">₱<?php echo e(number_format($ci->subtotal, 2)); ?></p>
-                                            </div>
-                                        </div>
-                                    <?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
-                                </div>
+                        <?php if($isMixedOrder): ?>
+                            <!-- Mixed Order Breakdown -->
+                            <div class="mt-4 space-y-4">
+                                <!-- Standard Items -->
                                 <?php if($standardItems->isNotEmpty()): ?>
-                                    <p class="mt-2 text-sm text-gray-700">Back order items subtotal: ₱<?php echo e(number_format($backOrderTotal, 2)); ?></p>
+                                    <div>
+                                        <h3 class="text-sm font-medium text-gray-900">Standard Items (100% Due)</h3>
+                                        <div class="mt-3 space-y-4">
+                                            <?php $__currentLoopData = $standardItems; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $ci): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+                                                <div class="flex items-center justify-between gap-4">
+                                                    <div class="flex items-center gap-3">
+                                                        <div class="w-16 h-16 rounded bg-gray-100 overflow-hidden">
+                                                            <img src="<?php echo e(optional($ci->item->photos->first())->url); ?>" alt="" class="w-full h-full object-cover"/>
+                                                        </div>
+                                                        <div>
+                                                            <p class="text-sm font-medium text-gray-900"><?php echo e($ci->item->name); ?></p>
+                                                            <p class="text-xs text-gray-500">Qty: <?php echo e($ci->quantity); ?></p>
+                                                        </div>
+                                                    </div>
+                                                    <div class="text-right">
+                                                        <p class="text-sm text-gray-900">₱<?php echo e(number_format($ci->subtotal, 2)); ?></p>
+                                                    </div>
+                                                </div>
+                                            <?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
+                                        </div>
+                                        <p class="mt-2 text-sm text-gray-700 font-medium">Standard subtotal: ₱<?php echo e(number_format($standardSubtotal, 2)); ?></p>
+                                    </div>
+                                <?php endif; ?>
+
+                                <!-- Back Order Items -->
+                                <?php if($backorderItems->isNotEmpty()): ?>
+                                    <div class="mt-6">
+                                        <div class="mb-3 p-3 bg-blue-50 border border-blue-100 rounded-lg">
+                                            <h3 class="text-sm font-medium text-blue-800">Back Order Items (50% Due Now)</h3>
+                                            <p class="mt-1 text-xs text-blue-700">These items are on back order. Pay 50% now, 50% when restocked.</p>
+                                        </div>
+                                        <div class="space-y-4">
+                                            <?php $__currentLoopData = $backorderItems; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $ci): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+                                                <div class="flex items-center justify-between gap-4">
+                                                    <div class="flex items-center gap-3">
+                                                        <div class="w-16 h-16 rounded bg-gray-100 overflow-hidden">
+                                                            <img src="<?php echo e(optional($ci->item->photos->first())->url); ?>" alt="" class="w-full h-full object-cover"/>
+                                                        </div>
+                                                        <div>
+                                                            <p class="text-sm font-medium text-gray-900"><?php echo e($ci->item->name); ?></p>
+                                                            <p class="text-xs text-gray-500">Qty: <?php echo e($ci->quantity); ?></p>
+                                                            <span class="inline-flex mt-1 px-2 py-0.5 text-[11px] rounded bg-blue-100 text-blue-800">Back-Order</span>
+                                                            <?php if($ci->item->restock_date): ?>
+                                                                <span class="block text-[11px] text-blue-700">Ships after <?php echo e($ci->item->restock_date->format('M d, Y')); ?></span>
+                                                            <?php endif; ?>
+                                                        </div>
+                                                    </div>
+                                                    <div class="text-right">
+                                                        <p class="text-sm text-gray-900">₱<?php echo e(number_format($ci->subtotal, 2)); ?></p>
+                                                        <p class="text-xs text-blue-600 font-medium">Pay now: ₱<?php echo e(number_format($ci->subtotal * 0.5, 2)); ?></p>
+                                                    </div>
+                                                </div>
+                                            <?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
+                                        </div>
+                                        <p class="mt-2 text-sm text-gray-700 font-medium">Back order subtotal: ₱<?php echo e(number_format($backorderSubtotal, 2)); ?></p>
+                                        <p class="mt-1 text-sm text-blue-700">50% Down: ₱<?php echo e(number_format($backorderSubtotal * 0.5, 2)); ?> | Remaining: ₱<?php echo e(number_format($backorderSubtotal * 0.5, 2)); ?></p>
+                                    </div>
                                 <?php endif; ?>
                             </div>
+                        <?php elseif(!$paymentOnly): ?>
+                            <!-- Non-Mixed Order Display (use existing variable names) -->
+                            <?php
+                                $nonMixedStdItems = $cartItems->filter(fn($ci) => !($ci->is_backorder ?? false));
+                                $nonMixedBackItems = $cartItems->filter(fn($ci) => ($ci->is_backorder ?? false));
+                            ?>
+                            <?php if($nonMixedStdItems->isNotEmpty()): ?>
+                                <div class="mt-4">
+                                    <h3 class="text-sm font-medium text-gray-900">Standard Items</h3>
+                                    <div class="mt-3 space-y-4">
+                                        <?php $__currentLoopData = $nonMixedStdItems; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $ci): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+                                            <div class="flex items-center justify-between gap-4">
+                                                <div class="flex items-center gap-3">
+                                                    <div class="w-16 h-16 rounded bg-gray-100 overflow-hidden">
+                                                        <img src="<?php echo e(optional($ci->item->photos->first())->url); ?>" alt="" class="w-full h-full object-cover"/>
+                                                    </div>
+                                                    <div>
+                                                        <p class="text-sm font-medium text-gray-900"><?php echo e($ci->item->name); ?></p>
+                                                        <p class="text-xs text-gray-500">Qty: <?php echo e($ci->quantity); ?></p>
+                                                    </div>
+                                                </div>
+                                                <div class="text-right">
+                                                    <p class="text-sm text-gray-900">₱<?php echo e(number_format($ci->subtotal, 2)); ?></p>
+                                                </div>
+                                            </div>
+                                        <?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
+                                    </div>
+                                    <?php if($nonMixedBackItems->isNotEmpty()): ?>
+                                        <p class="mt-2 text-sm text-gray-700">Standard items subtotal: ₱<?php echo e(number_format($nonMixedStdItems->sum('subtotal'), 2)); ?></p>
+                                    <?php endif; ?>
+                                </div>
+                            <?php endif; ?>
+
+                            <?php if($nonMixedBackItems->isNotEmpty()): ?>
+                                <div class="mt-6">
+                                    <div class="mb-3 p-3 bg-blue-50 border border-blue-100 rounded-lg">
+                                        <h3 class="text-sm font-medium text-blue-800">Back Order Items</h3>
+                                        <p class="mt-1 text-xs text-blue-700">These items will be shipped separately once they're back in stock.</p>
+                                    </div>
+                                    <div class="space-y-4">
+                                        <?php $__currentLoopData = $nonMixedBackItems; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $ci): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+                                            <div class="flex items-center justify-between gap-4">
+                                                <div class="flex items-center gap-3">
+                                                    <div class="w-16 h-16 rounded bg-gray-100 overflow-hidden">
+                                                        <img src="<?php echo e(optional($ci->item->photos->first())->url); ?>" alt="" class="w-full h-full object-cover"/>
+                                                    </div>
+                                                    <div>
+                                                        <p class="text-sm font-medium text-gray-900"><?php echo e($ci->item->name); ?></p>
+                                                        <p class="text-xs text-gray-500">Qty: <?php echo e($ci->quantity); ?></p>
+                                                        <span class="inline-flex mt-1 px-2 py-0.5 text-[11px] rounded bg-blue-100 text-blue-800">Back-Order</span>
+                                                        <?php if($ci->item->restock_date): ?>
+                                                            <span class="block text-[11px] text-blue-700">Ships after <?php echo e($ci->item->restock_date->format('M d, Y')); ?></span>
+                                                        <?php endif; ?>
+                                                    </div>
+                                                </div>
+                                                <div class="text-right">
+                                                    <p class="text-sm text-gray-900">₱<?php echo e(number_format($ci->subtotal, 2)); ?></p>
+                                                </div>
+                                            </div>
+                                        <?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
+                                    </div>
+                                    <?php if($nonMixedStdItems->isNotEmpty()): ?>
+                                        <p class="mt-2 text-sm text-gray-700">Back order items subtotal: ₱<?php echo e(number_format($nonMixedBackItems->sum('subtotal'), 2)); ?></p>
+                                    <?php endif; ?>
+                                </div>
+                            <?php endif; ?>
                         <?php endif; ?>
                         </div>
 
@@ -172,11 +261,50 @@
 								</div>
 							</div>
 						<?php endif; ?>
-						<div class="flex items-center justify-between"><span class="text-gray-600">Subtotal</span><span>₱<?php echo e(number_format($total, 2)); ?></span></div>
+						<div class="flex items-center justify-between"><span class="text-gray-600">Subtotal</span><span>₱<?php echo e(number_format($subtotal, 2)); ?></span></div>
 						<?php if(!$paymentOnly): ?>
 							<div class="flex items-center justify-between"><span class="text-gray-600">Shipping</span><span>₱<?php echo e(number_format($shipping, 2)); ?></span></div>
 						<?php endif; ?>
-						<div class="flex items-center justify-between font-semibold text-gray-900"><span>Total</span><span>₱<?php echo e(number_format($total, 2)); ?></span></div>
+                        
+                        <?php
+                            $displayAmount = $requiredPaymentAmount ?? $total;
+                        ?>
+                        
+                        <?php if($isMixedOrder): ?>
+                            <div class="mt-3 space-y-2 border-t pt-3">
+                                <h3 class="font-semibold text-gray-900">Payment Breakdown</h3>
+                                <div class="flex items-center justify-between p-2 bg-green-50 rounded border border-green-200">
+                                    <span class="text-green-900">Standard Items (100%)</span>
+                                    <span class="font-semibold text-green-900">₱<?php echo e(number_format($standardSubtotal, 2)); ?></span>
+                                </div>
+                                <div class="flex items-center justify-between p-2 bg-blue-50 rounded border border-blue-200">
+                                    <span class="text-blue-900">Back Order (50% Down)</span>
+                                    <span class="font-semibold text-blue-900">₱<?php echo e(number_format($backorderSubtotal * 0.5, 2)); ?></span>
+                                </div>
+                                <div class="flex items-center justify-between p-3 bg-amber-50 rounded border-2 border-amber-300 mt-2">
+                                    <span class="font-bold text-amber-900">💰 Total Due Now</span>
+                                    <span class="font-bold text-lg text-amber-900">₱<?php echo e(number_format($requiredPaymentAmount, 2)); ?></span>
+                                </div>
+                                <p class="text-xs text-gray-600 italic">Remaining: ₱<?php echo e(number_format($backorderSubtotal * 0.5, 2)); ?> (due when back order items arrive)</p>
+                            </div>
+                        <?php elseif(($cartItems->contains(fn($ci) => ($ci->is_backorder ?? false)) && !$paymentOnly) || ($paymentOnly && ($payOrder->order_type === 'backorder' || $payOrder->order_type === 'custom'))): ?>
+                            <div class="mt-3 space-y-2 border-t pt-3">
+                                <?php if(!$paymentOnly): ?>
+                                    <h3 class="font-semibold text-gray-900">Payment Required (50% Down Payment)</h3>
+                                <?php endif; ?>
+                                <div class="flex items-center justify-between p-3 bg-amber-50 rounded border-2 border-amber-300">
+                                    <span class="font-bold text-amber-900">💰 Down Payment Due Now</span>
+                                    <span class="font-bold text-lg text-amber-900">₱<?php echo e(number_format($displayAmount, 2)); ?></span>
+                                </div>
+                                <p class="text-xs text-gray-600 italic">Remaining 50% (₱<?php echo e(number_format(($total - $displayAmount), 2)); ?>) will be due upon completion/arrival</p>
+                            </div>
+                        <?php else: ?>
+                            <div class="flex items-center justify-between font-semibold text-gray-900 p-3 bg-gray-100 rounded border border-gray-300 mt-3">
+                                <span>Total Amount Due</span>
+                                <span>₱<?php echo e(number_format($displayAmount, 2)); ?></span>
+                            </div>
+                        <?php endif; ?>
+                        
 						<p class="text-xs text-gray-500 mt-2">Tax and shipping cost will be calculated later.</p>
                         <?php if(!$paymentOnly && $cartItems->contains(fn($ci) => ($ci->is_backorder ?? false))): ?>
                             <p class="text-xs text-blue-700 mt-1">This item is on back order. We'll ship it once restocked.</p>
@@ -236,9 +364,12 @@ const completeBtn = document.getElementById('completeBtn');
 const form = document.querySelector('form[action="<?php echo e(route('checkout.store')); ?>"]');
 const gcashModal = document.getElementById('gcashModal');
 const bankModal = document.getElementById('bankModal');
-// If paying an existing order, expose IDs for JS
+
+// Payment tracking
 window.payOrderId = <?php echo e(isset($payOrder) && $payOrder ? $payOrder->id : 'null'); ?>;
 window.payAmount = <?php echo e(isset($payOrder) && $payOrder ? (float) $payOrder->total_amount : 0); ?>;
+window.requiredPaymentAmount = <?php echo e($requiredPaymentAmount ?? 0); ?>;
+window.isMixedOrder = <?php echo e(isset($isMixedOrder) && $isMixedOrder ? 'true' : 'false'); ?>;
 
 function openModal(id){ const el = document.getElementById(id); el.classList.remove('hidden'); el.classList.add('flex'); }
 function closeModal(id){ const el = document.getElementById(id); el.classList.add('hidden'); el.classList.remove('flex'); }
@@ -246,7 +377,7 @@ function closeModal(id){ const el = document.getElementById(id); el.classList.ad
 async function createOrder() {
 	// If this is payment-only for an existing order, skip order creation
 	if(window.payOrderId){
-		return { success: true, order_id: window.payOrderId, total: window.payAmount };
+		return { success: true, order_id: window.payOrderId, total: window.payAmount, required: window.requiredPaymentAmount };
 	}
 	const data = new FormData(form);
 	const res = await fetch(form.action, { 
@@ -298,7 +429,8 @@ document.getElementById('gcashConfirmBtn').addEventListener('click', async () =>
 	if(ref.length < 6){ err.textContent = 'Reference number must be at least 6 characters.'; err.classList.remove('hidden'); return; }
 	try{
 		const o = await createOrder();
-		const params = new URLSearchParams({ order_id: o.order_id, amount: o.total, reference: ref });
+		const requiredAmount = o.required ?? o.total;
+		const params = new URLSearchParams({ order_id: o.order_id, amount: requiredAmount, reference: ref });
 		const res = await fetch('<?php echo e(route('payments.gcash')); ?>', { method:'POST', headers:{ 'X-CSRF-TOKEN': csrf }, body: params });
 		if(!res.ok) {
 			const errData = await res.json().catch(() => ({}));
@@ -320,9 +452,10 @@ document.getElementById('bankSubmitBtn').addEventListener('click', async () => {
 	if(!file){ err.textContent = 'Please upload an image of the deposit slip.'; err.classList.remove('hidden'); return; }
 	try{
 		const o = await createOrder();
+		const requiredAmount = o.required ?? o.total;
 		const fd = new FormData();
 		fd.append('order_id', o.order_id);
-		fd.append('amount', o.total);
+		fd.append('amount', requiredAmount);
 		fd.append('proof', file);
 		const res = await fetch('<?php echo e(route('payments.bank')); ?>', { method:'POST', headers:{ 'X-CSRF-TOKEN': csrf }, body: fd });
 		if(!res.ok) {

--- a/storage/framework/views/7ccdffcb63a52576011547acfc428211.php
+++ b/storage/framework/views/7ccdffcb63a52576011547acfc428211.php
@@ -1,0 +1,194 @@
+<script>
+
+    (function () {
+        const darkStyles = document.querySelector('style[data-theme="dark"]')?.textContent
+        const lightStyles = document.querySelector('style[data-theme="light"]')?.textContent
+
+        const removeStyles = () => {
+            document.querySelector('style[data-theme="dark"]')?.remove()
+            document.querySelector('style[data-theme="light"]')?.remove()
+        }
+
+        removeStyles()
+
+        setDarkClass = () => {
+            removeStyles()
+
+            const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)
+
+            isDark ? document.documentElement.classList.add('dark') : document.documentElement.classList.remove('dark')
+
+            if (isDark) {
+                document.head.insertAdjacentHTML('beforeend', `<style data-theme="dark">${darkStyles}</style>`)
+            } else {
+                document.head.insertAdjacentHTML('beforeend', `<style data-theme="light">${lightStyles}</style>`)
+            }
+        }
+
+        setDarkClass()
+
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', setDarkClass)
+    })();
+</script>
+
+<div
+    class="relative"
+    x-data="{
+        menu: false,
+        theme: localStorage.theme,
+        darkMode() {
+            this.theme = 'dark'
+            localStorage.theme = 'dark'
+            setDarkClass()
+        },
+        lightMode() {
+            this.theme = 'light'
+            localStorage.theme = 'light'
+            setDarkClass()
+        },
+        systemMode() {
+            this.theme = undefined
+            localStorage.removeItem('theme')
+            setDarkClass()
+        },
+    }"
+    @click.outside="menu = false"
+>
+    <button
+        x-cloak
+        class="block rounded p-1 hover:bg-gray-100 dark:hover:bg-gray-800"
+        :class="theme ? 'text-gray-700 dark:text-gray-300' : 'text-gray-400 dark:text-gray-600 hover:text-gray-500 focus:text-gray-500 dark:hover:text-gray-500 dark:focus:text-gray-500'"
+        @click="menu = ! menu"
+    >
+        <?php if (isset($component)) { $__componentOriginalbfde029a2e31d1ec96b5017ff81a67a7 = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginalbfde029a2e31d1ec96b5017ff81a67a7 = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.icons.sun','data' => ['class' => 'block h-5 w-5 dark:hidden']] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::icons.sun'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes(['class' => 'block h-5 w-5 dark:hidden']); ?>
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginalbfde029a2e31d1ec96b5017ff81a67a7)): ?>
+<?php $attributes = $__attributesOriginalbfde029a2e31d1ec96b5017ff81a67a7; ?>
+<?php unset($__attributesOriginalbfde029a2e31d1ec96b5017ff81a67a7); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginalbfde029a2e31d1ec96b5017ff81a67a7)): ?>
+<?php $component = $__componentOriginalbfde029a2e31d1ec96b5017ff81a67a7; ?>
+<?php unset($__componentOriginalbfde029a2e31d1ec96b5017ff81a67a7); ?>
+<?php endif; ?>
+        <?php if (isset($component)) { $__componentOriginal6dda8ad3ea7f20f6c0a87e7037386745 = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal6dda8ad3ea7f20f6c0a87e7037386745 = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.icons.moon','data' => ['class' => 'hidden h-5 w-5 dark:block']] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::icons.moon'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes(['class' => 'hidden h-5 w-5 dark:block']); ?>
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal6dda8ad3ea7f20f6c0a87e7037386745)): ?>
+<?php $attributes = $__attributesOriginal6dda8ad3ea7f20f6c0a87e7037386745; ?>
+<?php unset($__attributesOriginal6dda8ad3ea7f20f6c0a87e7037386745); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal6dda8ad3ea7f20f6c0a87e7037386745)): ?>
+<?php $component = $__componentOriginal6dda8ad3ea7f20f6c0a87e7037386745; ?>
+<?php unset($__componentOriginal6dda8ad3ea7f20f6c0a87e7037386745); ?>
+<?php endif; ?>
+    </button>
+
+    <div
+        x-show="menu"
+        class="absolute right-0 z-10 flex origin-top-right flex-col rounded-md bg-white shadow-xl ring-1 ring-gray-900/5 dark:bg-gray-800"
+        style="display: none"
+        @click="menu = false"
+    >
+        <button
+            class="flex items-center gap-3 px-4 py-2 hover:rounded-t-md hover:bg-gray-100 dark:hover:bg-gray-700"
+            :class="theme === 'light' ? 'text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'"
+            @click="lightMode()"
+        >
+            <?php if (isset($component)) { $__componentOriginalbfde029a2e31d1ec96b5017ff81a67a7 = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginalbfde029a2e31d1ec96b5017ff81a67a7 = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.icons.sun','data' => ['class' => 'h-5 w-5']] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::icons.sun'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes(['class' => 'h-5 w-5']); ?>
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginalbfde029a2e31d1ec96b5017ff81a67a7)): ?>
+<?php $attributes = $__attributesOriginalbfde029a2e31d1ec96b5017ff81a67a7; ?>
+<?php unset($__attributesOriginalbfde029a2e31d1ec96b5017ff81a67a7); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginalbfde029a2e31d1ec96b5017ff81a67a7)): ?>
+<?php $component = $__componentOriginalbfde029a2e31d1ec96b5017ff81a67a7; ?>
+<?php unset($__componentOriginalbfde029a2e31d1ec96b5017ff81a67a7); ?>
+<?php endif; ?>
+            Light
+        </button>
+        <button
+            class="flex items-center gap-3 px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+            :class="theme === 'dark' ? 'text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'"
+            @click="darkMode()"
+        >
+            <?php if (isset($component)) { $__componentOriginal6dda8ad3ea7f20f6c0a87e7037386745 = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal6dda8ad3ea7f20f6c0a87e7037386745 = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.icons.moon','data' => ['class' => 'h-5 w-5']] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::icons.moon'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes(['class' => 'h-5 w-5']); ?>
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal6dda8ad3ea7f20f6c0a87e7037386745)): ?>
+<?php $attributes = $__attributesOriginal6dda8ad3ea7f20f6c0a87e7037386745; ?>
+<?php unset($__attributesOriginal6dda8ad3ea7f20f6c0a87e7037386745); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal6dda8ad3ea7f20f6c0a87e7037386745)): ?>
+<?php $component = $__componentOriginal6dda8ad3ea7f20f6c0a87e7037386745; ?>
+<?php unset($__componentOriginal6dda8ad3ea7f20f6c0a87e7037386745); ?>
+<?php endif; ?>
+            Dark
+        </button>
+        <button
+            class="flex items-center gap-3 px-4 py-2 hover:rounded-b-md hover:bg-gray-100 dark:hover:bg-gray-700"
+            :class="theme === undefined ? 'text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'"
+            @click="systemMode()"
+        >
+            <?php if (isset($component)) { $__componentOriginala52e607cb40b8eec566206ff9f3ca13c = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginala52e607cb40b8eec566206ff9f3ca13c = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.icons.computer-desktop','data' => ['class' => 'h-5 w-5']] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::icons.computer-desktop'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes(['class' => 'h-5 w-5']); ?>
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginala52e607cb40b8eec566206ff9f3ca13c)): ?>
+<?php $attributes = $__attributesOriginala52e607cb40b8eec566206ff9f3ca13c; ?>
+<?php unset($__attributesOriginala52e607cb40b8eec566206ff9f3ca13c); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginala52e607cb40b8eec566206ff9f3ca13c)): ?>
+<?php $component = $__componentOriginala52e607cb40b8eec566206ff9f3ca13c; ?>
+<?php unset($__componentOriginala52e607cb40b8eec566206ff9f3ca13c); ?>
+<?php endif; ?>
+            System
+        </button>
+    </div>
+</div>
+<?php /**PATH C:\xampp\htdocs\wowc\vendor\laravel\framework\src\Illuminate\Foundation\Providers/../resources/exceptions/renderer/components/theme-switcher.blade.php ENDPATH**/ ?>

--- a/storage/framework/views/841d37001e21fd78813044d307dd8937.php
+++ b/storage/framework/views/841d37001e21fd78813044d307dd8937.php
@@ -1,0 +1,33 @@
+<?php $__currentLoopData = $exception->frames(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $frame): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+    <div
+        class="sm:col-span-2"
+        x-show="index === <?php echo e($loop->index); ?>"
+    >
+        <div class="mb-3">
+            <div class="text-md text-gray-500 dark:text-gray-400">
+                <div class="mb-2">
+
+                    <?php if(config('app.editor')): ?>
+                        <a href="<?php echo e($frame->editorHref()); ?>" class="text-blue-500 hover:underline">
+                            <span class="wrap text-gray-900 dark:text-gray-300"><?php echo e($frame->file()); ?></span>
+                        </a>
+                    <?php else: ?>
+                        <span class="wrap text-gray-900 dark:text-gray-300"><?php echo e($frame->file()); ?></span>
+                    <?php endif; ?>
+
+                    <span class="font-mono text-xs">:<?php echo e($frame->line()); ?></span>
+                </div>
+            </div>
+        </div>
+        <div class="pt-4 text-sm text-gray-500 dark:text-gray-400">
+            <pre class="h-[32.5rem] rounded-md dark:bg-gray-800 border dark:border-gray-700"><template x-if="true"><code
+                    style="display: none;"
+                    id="frame-<?php echo e($loop->index); ?>"
+                    class="language-php highlightable-code <?php if($loop->index === $exception->defaultFrame()): ?> default-highlightable-code <?php endif; ?> scrollbar-hidden overflow-y-hidden"
+                    data-line-number="<?php echo e($frame->line()); ?>"
+                    data-ln-start-from="<?php echo e(max($frame->line() - 5, 1)); ?>"
+                ><?php echo e($frame->snippet()); ?></code></template></pre>
+        </div>
+    </div>
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
+<?php /**PATH C:\xampp\htdocs\wowc\vendor\laravel\framework\src\Illuminate\Foundation\Providers/../resources/exceptions/renderer/components/editor.blade.php ENDPATH**/ ?>

--- a/storage/framework/views/852253897280fe1ec9dc2749079624e9.php
+++ b/storage/framework/views/852253897280fe1ec9dc2749079624e9.php
@@ -1,0 +1,70 @@
+<?php if (isset($component)) { $__componentOriginal74daf2d0a9c625ad90327a6043d15980 = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal74daf2d0a9c625ad90327a6043d15980 = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.card','data' => ['class' => 'mt-6 overflow-x-auto']] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::card'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes(['class' => 'mt-6 overflow-x-auto']); ?>
+    <div
+        x-data="{
+            includeVendorFrames: false,
+            index: <?php echo e($exception->defaultFrame()); ?>,
+        }"
+    >
+        <div class="grid grid-cols-1 gap-6 lg:grid-cols-3" x-clock>
+            <?php if (isset($component)) { $__componentOriginal92c1a431b4816bac5d5a20d0fc1238ab = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal92c1a431b4816bac5d5a20d0fc1238ab = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.trace','data' => ['exception' => $exception]] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::trace'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes(['exception' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute($exception)]); ?>
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal92c1a431b4816bac5d5a20d0fc1238ab)): ?>
+<?php $attributes = $__attributesOriginal92c1a431b4816bac5d5a20d0fc1238ab; ?>
+<?php unset($__attributesOriginal92c1a431b4816bac5d5a20d0fc1238ab); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal92c1a431b4816bac5d5a20d0fc1238ab)): ?>
+<?php $component = $__componentOriginal92c1a431b4816bac5d5a20d0fc1238ab; ?>
+<?php unset($__componentOriginal92c1a431b4816bac5d5a20d0fc1238ab); ?>
+<?php endif; ?>
+            <?php if (isset($component)) { $__componentOriginala2de13eefed6710e7b4064d57c6d0e47 = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginala2de13eefed6710e7b4064d57c6d0e47 = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.editor','data' => ['exception' => $exception]] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::editor'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes(['exception' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute($exception)]); ?>
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginala2de13eefed6710e7b4064d57c6d0e47)): ?>
+<?php $attributes = $__attributesOriginala2de13eefed6710e7b4064d57c6d0e47; ?>
+<?php unset($__attributesOriginala2de13eefed6710e7b4064d57c6d0e47); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginala2de13eefed6710e7b4064d57c6d0e47)): ?>
+<?php $component = $__componentOriginala2de13eefed6710e7b4064d57c6d0e47; ?>
+<?php unset($__componentOriginala2de13eefed6710e7b4064d57c6d0e47); ?>
+<?php endif; ?>
+        </div>
+    </div>
+ <?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal74daf2d0a9c625ad90327a6043d15980)): ?>
+<?php $attributes = $__attributesOriginal74daf2d0a9c625ad90327a6043d15980; ?>
+<?php unset($__attributesOriginal74daf2d0a9c625ad90327a6043d15980); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal74daf2d0a9c625ad90327a6043d15980)): ?>
+<?php $component = $__componentOriginal74daf2d0a9c625ad90327a6043d15980; ?>
+<?php unset($__componentOriginal74daf2d0a9c625ad90327a6043d15980); ?>
+<?php endif; ?>
+<?php /**PATH C:\xampp\htdocs\wowc\vendor\laravel\framework\src\Illuminate\Foundation\Providers/../resources/exceptions/renderer/components/trace-and-editor.blade.php ENDPATH**/ ?>

--- a/storage/framework/views/88ec2c7d51fc650d13e08db54087666a.php
+++ b/storage/framework/views/88ec2c7d51fc650d13e08db54087666a.php
@@ -1,0 +1,59 @@
+# <?php echo e($exception->class()); ?> - <?php echo $exception->title(); ?>
+
+<?php echo $exception->message(); ?>
+
+
+PHP <?php echo e(PHP_VERSION); ?>
+
+Laravel <?php echo e(app()->version()); ?>
+
+<?php echo e($exception->request()->httpHost()); ?>
+
+
+## Stack Trace
+
+<?php $__currentLoopData = $exception->frames(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $index => $frame): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+<?php echo e($index); ?> - <?php echo e($frame->file()); ?>:<?php echo e($frame->line()); ?>
+
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
+
+## Request
+
+<?php echo e($exception->request()->method()); ?> <?php echo e(Str::start($exception->request()->path(), '/')); ?>
+
+
+## Headers
+
+<?php $__empty_1 = true; $__currentLoopData = $exception->requestHeaders(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $key => $value): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $__empty_1 = false; ?>
+* **<?php echo e($key); ?>**: <?php echo $value; ?>
+
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); if ($__empty_1): ?>
+No header data available.
+<?php endif; ?>
+
+## Route Context
+
+<?php $__empty_1 = true; $__currentLoopData = $exception->applicationRouteContext(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $name => $value): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $__empty_1 = false; ?>
+<?php echo e($name); ?>: <?php echo $value; ?>
+
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); if ($__empty_1): ?>
+No routing data available.
+<?php endif; ?>
+
+## Route Parameters
+
+<?php if($routeParametersContext = $exception->applicationRouteParametersContext()): ?>
+<?php echo $routeParametersContext; ?>
+
+<?php else: ?>
+No route parameter data available.
+<?php endif; ?>
+
+## Database Queries
+
+<?php $__empty_1 = true; $__currentLoopData = $exception->applicationQueries(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as ['connectionName' => $connectionName, 'sql' => $sql, 'time' => $time]): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $__empty_1 = false; ?>
+* <?php echo e($connectionName); ?> - <?php echo $sql; ?> (<?php echo e($time); ?> ms)
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); if ($__empty_1): ?>
+No database queries detected.
+<?php endif; ?>
+<?php /**PATH C:\xampp\htdocs\wowc\vendor\laravel\framework\src\Illuminate\Foundation\Providers/../resources/exceptions/renderer/markdown.blade.php ENDPATH**/ ?>

--- a/storage/framework/views/a928f31849d27c32a7827be429423a48.php
+++ b/storage/framework/views/a928f31849d27c32a7827be429423a48.php
@@ -1,0 +1,164 @@
+<div class="hidden overflow-x-auto sm:col-span-1 lg:block">
+    <div
+        class="h-[35.5rem] scrollbar-hidden trace text-sm text-gray-400 dark:text-gray-300"
+    >
+        <div class="mb-2 inline-block rounded-full bg-red-500/20 px-3 py-2 dark:bg-red-500/20 sm:col-span-1">
+            <button
+                @click="includeVendorFrames = !includeVendorFrames"
+                class="inline-flex items-center font-bold leading-5 text-red-500"
+            >
+                <span x-show="includeVendorFrames">Collapse</span>
+                <span
+                    x-cloak
+                    x-show="!includeVendorFrames"
+                    >Expand</span
+                >
+                <span class="ml-1">vendor frames</span>
+
+                <div class="flex flex-col ml-1 -mt-2" x-cloak x-show="includeVendorFrames">
+                    <?php if (isset($component)) { $__componentOriginal707ceba27255eae48fdb0f3529710ddf = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal707ceba27255eae48fdb0f3529710ddf = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.icons.chevron-down','data' => []] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::icons.chevron-down'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes([]); ?>
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal707ceba27255eae48fdb0f3529710ddf)): ?>
+<?php $attributes = $__attributesOriginal707ceba27255eae48fdb0f3529710ddf; ?>
+<?php unset($__attributesOriginal707ceba27255eae48fdb0f3529710ddf); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal707ceba27255eae48fdb0f3529710ddf)): ?>
+<?php $component = $__componentOriginal707ceba27255eae48fdb0f3529710ddf; ?>
+<?php unset($__componentOriginal707ceba27255eae48fdb0f3529710ddf); ?>
+<?php endif; ?>
+                    <?php if (isset($component)) { $__componentOriginal14b1cc5db95fcca4a0f06445821cff39 = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal14b1cc5db95fcca4a0f06445821cff39 = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.icons.chevron-up','data' => []] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::icons.chevron-up'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes([]); ?>
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal14b1cc5db95fcca4a0f06445821cff39)): ?>
+<?php $attributes = $__attributesOriginal14b1cc5db95fcca4a0f06445821cff39; ?>
+<?php unset($__attributesOriginal14b1cc5db95fcca4a0f06445821cff39); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal14b1cc5db95fcca4a0f06445821cff39)): ?>
+<?php $component = $__componentOriginal14b1cc5db95fcca4a0f06445821cff39; ?>
+<?php unset($__componentOriginal14b1cc5db95fcca4a0f06445821cff39); ?>
+<?php endif; ?>
+                </div>
+
+                <div class="flex flex-col ml-1 -mt-2" x-cloak x-show="! includeVendorFrames">
+                    <?php if (isset($component)) { $__componentOriginal14b1cc5db95fcca4a0f06445821cff39 = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal14b1cc5db95fcca4a0f06445821cff39 = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.icons.chevron-up','data' => []] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::icons.chevron-up'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes([]); ?>
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal14b1cc5db95fcca4a0f06445821cff39)): ?>
+<?php $attributes = $__attributesOriginal14b1cc5db95fcca4a0f06445821cff39; ?>
+<?php unset($__attributesOriginal14b1cc5db95fcca4a0f06445821cff39); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal14b1cc5db95fcca4a0f06445821cff39)): ?>
+<?php $component = $__componentOriginal14b1cc5db95fcca4a0f06445821cff39; ?>
+<?php unset($__componentOriginal14b1cc5db95fcca4a0f06445821cff39); ?>
+<?php endif; ?>
+                    <?php if (isset($component)) { $__componentOriginal707ceba27255eae48fdb0f3529710ddf = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal707ceba27255eae48fdb0f3529710ddf = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.icons.chevron-down','data' => []] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::icons.chevron-down'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes([]); ?>
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal707ceba27255eae48fdb0f3529710ddf)): ?>
+<?php $attributes = $__attributesOriginal707ceba27255eae48fdb0f3529710ddf; ?>
+<?php unset($__attributesOriginal707ceba27255eae48fdb0f3529710ddf); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal707ceba27255eae48fdb0f3529710ddf)): ?>
+<?php $component = $__componentOriginal707ceba27255eae48fdb0f3529710ddf; ?>
+<?php unset($__componentOriginal707ceba27255eae48fdb0f3529710ddf); ?>
+<?php endif; ?>
+                </div>
+            </button>
+        </div>
+
+        <div class="mb-12 space-y-2">
+            <?php $__currentLoopData = $exception->frames(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $frame): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+                <?php if(! $frame->isFromVendor()): ?>
+                    <?php
+                        $vendorFramesCollapsed = $exception->frames()->take($loop->index)->reverse()->takeUntil(fn ($frame) => ! $frame->isFromVendor());
+                    ?>
+
+                    <div x-show="! includeVendorFrames">
+                        <?php if($vendorFramesCollapsed->isNotEmpty()): ?>
+                            <div class="text-gray-500">
+                                <?php echo e($vendorFramesCollapsed->count()); ?> vendor frame<?php echo e($vendorFramesCollapsed->count() > 1 ? 's' : ''); ?> collapsed
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                <?php endif; ?>
+
+                <button
+                    class="w-full text-left dark:border-gray-900"
+                    x-show="<?php echo e($frame->isFromVendor() ? 'includeVendorFrames' : 'true'); ?>"
+                    @click="index = <?php echo e($loop->index); ?>"
+                >
+                    <div
+                        x-bind:class="
+                            index === <?php echo e($loop->index); ?>
+
+                                ? 'rounded-r-md bg-gray-100 dark:bg-gray-800 border-l dark:border dark:border-gray-700 border-l-red-500 dark:border-l-red-500'
+                                : 'hover:bg-gray-100/75 dark:hover:bg-gray-800/75'
+                        "
+                    >
+                        <div class="scrollbar-hidden overflow-x-auto border-l-2 border-transparent p-2">
+                            <div class="nowrap text-gray-900 dark:text-gray-300">
+                                <span class="inline-flex items-baseline">
+                                    <span class="text-gray-900 dark:text-gray-300"><?php echo e($frame->source()); ?></span>
+                                    <span class="font-mono text-xs">:<?php echo e($frame->line()); ?></span>
+                                </span>
+                            </div>
+                            <div class="text-gray-500 dark:text-gray-400">
+                                <?php echo e($exception->frames()->get($loop->index + 1)?->callable()); ?>
+
+                            </div>
+                        </div>
+                    </div>
+                </button>
+
+                <?php if(! $frame->isFromVendor() && $exception->frames()->slice($loop->index + 1)->reject(fn ($frame) => $frame->isFromVendor())->isEmpty()): ?>
+                    <?php if($exception->frames()->slice($loop->index + 1)->count()): ?>
+                        <div x-show="! includeVendorFrames">
+                            <div class="text-gray-500">
+                                <?php echo e($exception->frames()->slice($loop->index + 1)->count()); ?> vendor
+                                frame<?php echo e($exception->frames()->slice($loop->index + 1)->count() > 1 ? 's' : ''); ?> collapsed
+                            </div>
+                        </div>
+                    <?php endif; ?>
+                <?php endif; ?>
+            <?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
+        </div>
+    </div>
+</div>
+<?php /**PATH C:\xampp\htdocs\wowc\vendor\laravel\framework\src\Illuminate\Foundation\Providers/../resources/exceptions/renderer/components/trace.blade.php ENDPATH**/ ?>

--- a/storage/framework/views/af02cca9c488c4da89c63ae75711320f.php
+++ b/storage/framework/views/af02cca9c488c4da89c63ae75711320f.php
@@ -1,0 +1,186 @@
+<?php use \Illuminate\Support\Str; ?>
+<?php if (isset($component)) { $__componentOriginal74daf2d0a9c625ad90327a6043d15980 = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal74daf2d0a9c625ad90327a6043d15980 = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.card','data' => ['class' => 'mt-6 overflow-x-auto']] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::card'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes(['class' => 'mt-6 overflow-x-auto']); ?>
+    <div>
+        <span class="text-xl font-bold lg:text-2xl">Request</span>
+    </div>
+
+    <div class="mt-2">
+        <span><?php echo e($exception->request()->method()); ?></span>
+        <span class="text-gray-500"><?php echo e(Str::start($exception->request()->path(), '/')); ?></span>
+    </div>
+
+    <div class="mt-4">
+        <span class="font-semibold text-gray-900 dark:text-white">Headers</span>
+    </div>
+
+    <dl class="mt-1 grid grid-cols-1 rounded border dark:border-gray-800">
+        <?php $__empty_1 = true; $__currentLoopData = $exception->requestHeaders(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $key => $value): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $__empty_1 = false; ?>
+            <div class="flex items-center gap-2 <?php echo e($loop->first ? '' : 'border-t'); ?> dark:border-gray-800">
+                <span
+                    data-tippy-content="<?php echo e($key); ?>"
+                    class="lg:text-md w-[8rem] flex-none cursor-pointer truncate border-r px-5 py-3 text-sm dark:border-gray-800 lg:w-[12rem]"
+                >
+                    <?php echo e($key); ?>
+
+                </span>
+                <span
+                    class="min-w-0 flex-grow"
+                    style="
+                        -webkit-mask-image: linear-gradient(90deg, transparent 0, #000 1rem, #000 calc(100% - 3rem), transparent calc(100% - 1rem));
+                    "
+                >
+                    <pre class="scrollbar-hidden overflow-y-hidden text-xs lg:text-sm"><code class="px-5 py-3 overflow-y-hidden scrollbar-hidden max-h-32 overflow-x-scroll scrollbar-hidden-x"><?php echo e($value); ?></code></pre>
+                </span>
+            </div>
+        <?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); if ($__empty_1): ?>
+            <span
+                class="min-w-0 flex-grow"
+                style="-webkit-mask-image: linear-gradient(90deg, transparent 0, #000 1rem, #000 calc(100% - 3rem), transparent calc(100% - 1rem))"
+            >
+                <pre class="scrollbar-hidden mx-5 my-3 overflow-y-hidden text-xs lg:text-sm"><code class="overflow-y-hidden scrollbar-hidden overflow-x-scroll scrollbar-hidden-x">No headers data</code></pre>
+            </span>
+        <?php endif; ?>
+    </dl>
+
+    <div class="mt-4">
+        <span class="font-semibold text-gray-900 dark:text-white">Body</span>
+    </div>
+
+    <div class="mt-1 rounded border dark:border-gray-800">
+        <div class="flex items-center">
+            <span
+                class="min-w-0 flex-grow"
+                style="-webkit-mask-image: linear-gradient(90deg, transparent 0, #000 1rem, #000 calc(100% - 3rem), transparent calc(100% - 1rem))"
+            >
+                <pre class="scrollbar-hidden mx-5 my-3 overflow-y-hidden text-xs lg:text-sm"><code class="overflow-y-hidden scrollbar-hidden overflow-x-scroll scrollbar-hidden-x"><?php echo e($exception->requestBody() ?: 'No body data'); ?></code></pre>
+            </span>
+        </div>
+    </div>
+
+ <?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal74daf2d0a9c625ad90327a6043d15980)): ?>
+<?php $attributes = $__attributesOriginal74daf2d0a9c625ad90327a6043d15980; ?>
+<?php unset($__attributesOriginal74daf2d0a9c625ad90327a6043d15980); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal74daf2d0a9c625ad90327a6043d15980)): ?>
+<?php $component = $__componentOriginal74daf2d0a9c625ad90327a6043d15980; ?>
+<?php unset($__componentOriginal74daf2d0a9c625ad90327a6043d15980); ?>
+<?php endif; ?>
+
+<?php if (isset($component)) { $__componentOriginal74daf2d0a9c625ad90327a6043d15980 = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal74daf2d0a9c625ad90327a6043d15980 = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'laravel-exceptions-renderer::components.card','data' => ['class' => 'mt-6 overflow-x-auto']] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('laravel-exceptions-renderer::card'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes(['class' => 'mt-6 overflow-x-auto']); ?>
+    <div>
+        <span class="text-xl font-bold lg:text-2xl">Application</span>
+    </div>
+
+    <div class="mt-4">
+        <span class="font-semibold text-gray-900 dark:text-white"> Routing </span>
+    </div>
+
+    <dl class="mt-1 grid grid-cols-1 rounded border dark:border-gray-800">
+        <?php $__empty_1 = true; $__currentLoopData = $exception->applicationRouteContext(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $name => $value): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $__empty_1 = false; ?>
+            <div class="flex items-center gap-2 <?php echo e($loop->first ? '' : 'border-t'); ?> dark:border-gray-800">
+                <span
+                    data-tippy-content="<?php echo e($name); ?>"
+                    class="lg:text-md w-[8rem] flex-none cursor-pointer truncate border-r px-5 py-3 text-sm dark:border-gray-800 lg:w-[12rem]"
+                    ><?php echo e($name); ?></span
+                >
+                <span
+                    class="min-w-0 flex-grow"
+                    style="
+                        -webkit-mask-image: linear-gradient(90deg, transparent 0, #000 1rem, #000 calc(100% - 3rem), transparent calc(100% - 1rem));
+                    "
+                >
+                    <pre class="scrollbar-hidden overflow-y-hidden text-xs lg:text-sm"><code class="px-5 py-3 overflow-y-hidden scrollbar-hidden max-h-32 overflow-x-scroll scrollbar-hidden-x"><?php echo e($value); ?></code></pre>
+                </span>
+            </div>
+        <?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); if ($__empty_1): ?>
+            <span
+                class="min-w-0 flex-grow"
+                style="-webkit-mask-image: linear-gradient(90deg, transparent 0, #000 1rem, #000 calc(100% - 3rem), transparent calc(100% - 1rem))"
+            >
+                <pre class="scrollbar-hidden mx-5 my-3 overflow-y-hidden text-xs lg:text-sm"><code class="overflow-y-hidden scrollbar-hidden overflow-x-scroll scrollbar-hidden-x">No routing data</code></pre>
+            </span>
+        <?php endif; ?>
+    </dl>
+
+    <?php if($routeParametersContext = $exception->applicationRouteParametersContext()): ?>
+        <div class="mt-4">
+            <span class="text-gray-900 dark:text-white text-sm"> Routing Parameters </span>
+        </div>
+
+        <div class="mt-1 rounded border dark:border-gray-800">
+            <div class="flex items-center">
+                <span
+                    class="min-w-0 flex-grow"
+                    style="-webkit-mask-image: linear-gradient(90deg, transparent 0, #000 1rem, #000 calc(100% - 3rem), transparent calc(100% - 1rem))"
+                >
+                    <pre class="scrollbar-hidden mx-5 my-3 overflow-y-hidden text-xs lg:text-sm"><code class="overflow-y-hidden scrollbar-hidden overflow-x-scroll scrollbar-hidden-x"><?php echo e($routeParametersContext); ?></code></pre>
+                </span>
+            </div>
+        </div>
+    <?php endif; ?>
+
+    <div class="mt-4">
+        <span class="font-semibold text-gray-900 dark:text-white"> Database Queries </span>
+        <span class="text-xs text-gray-500 dark:text-gray-400">
+            <?php if(count($exception->applicationQueries()) === 100): ?>
+                only the first 100 queries are displayed
+            <?php endif; ?>
+        </span>
+    </div>
+
+    <dl class="mt-1 grid grid-cols-1 rounded border dark:border-gray-800">
+        <?php $__empty_1 = true; $__currentLoopData = $exception->applicationQueries(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as ['connectionName' => $connectionName, 'sql' => $sql, 'time' => $time]): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $__empty_1 = false; ?>
+            <div class="flex items-center gap-2 <?php echo e($loop->first ? '' : 'border-t'); ?> dark:border-gray-800">
+                <div class="lg:text-md w-[8rem] flex-none truncate border-r px-5 py-3 text-sm dark:border-gray-800 lg:w-[12rem]">
+                    <span><?php echo e($connectionName); ?></span>
+                    <span class="hidden text-xs text-gray-500 lg:inline-block">(<?php echo e($time); ?> ms)</span>
+                </div>
+                <span
+                    class="min-w-0 flex-grow"
+                    style="
+                        -webkit-mask-image: linear-gradient(90deg, transparent 0, #000 1rem, #000 calc(100% - 3rem), transparent calc(100% - 1rem));
+                    "
+                >
+                    <pre class="scrollbar-hidden overflow-y-hidden text-xs lg:text-sm"><code class="px-5 py-3 overflow-y-hidden scrollbar-hidden max-h-32 overflow-x-scroll scrollbar-hidden-x"><?php echo e($sql); ?></code></pre>
+                </span>
+            </div>
+        <?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); if ($__empty_1): ?>
+            <span
+                class="min-w-0 flex-grow"
+                style="-webkit-mask-image: linear-gradient(90deg, transparent 0, #000 1rem, #000 calc(100% - 3rem), transparent calc(100% - 1rem))"
+            >
+                <pre class="scrollbar-hidden mx-5 my-3 overflow-y-hidden text-xs lg:text-sm"><code class="overflow-y-hidden scrollbar-hidden overflow-x-scroll scrollbar-hidden-x">No query data</code></pre>
+            </span>
+        <?php endif; ?>
+    </dl>
+ <?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal74daf2d0a9c625ad90327a6043d15980)): ?>
+<?php $attributes = $__attributesOriginal74daf2d0a9c625ad90327a6043d15980; ?>
+<?php unset($__attributesOriginal74daf2d0a9c625ad90327a6043d15980); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal74daf2d0a9c625ad90327a6043d15980)): ?>
+<?php $component = $__componentOriginal74daf2d0a9c625ad90327a6043d15980; ?>
+<?php unset($__componentOriginal74daf2d0a9c625ad90327a6043d15980); ?>
+<?php endif; ?>
+<?php /**PATH C:\xampp\htdocs\wowc\vendor\laravel\framework\src\Illuminate\Foundation\Providers/../resources/exceptions/renderer/components/context.blade.php ENDPATH**/ ?>

--- a/storage/framework/views/fd2a56f9e0a517800fa7bbb8bec26ff5.php
+++ b/storage/framework/views/fd2a56f9e0a517800fa7bbb8bec26ff5.php
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4" style="margin-bottom: -8px;">
+    <path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
+</svg>
+<?php /**PATH C:\xampp\htdocs\wowc\vendor\laravel\framework\src\Illuminate\Foundation\Providers/../resources/exceptions/renderer/components/icons/chevron-down.blade.php ENDPATH**/ ?>

--- a/tests/Feature/MixedOrderSplitTest.php
+++ b/tests/Feature/MixedOrderSplitTest.php
@@ -1,0 +1,615 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Item;
+use App\Models\Cart;
+use App\Models\CartItem;
+use App\Models\Order;
+use App\Models\OrderItem;
+
+class MixedOrderSplitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test mixed order creation when customer checks out with both standard and backorder items
+     * @test
+     */
+    public function mixed_order_checkout_creates_parent_and_sub_orders()
+    {
+        $user = User::factory()->create();
+
+        // Create standard item with stock
+        $standardItem = Item::create([
+            'name' => 'Standard Item',
+            'price' => 100.00,
+            'stock' => 5,
+            'status' => 'in_stock',
+            'visible' => true,
+        ]);
+
+        // Create backorder item (out of stock)
+        $backorderItem = Item::create([
+            'name' => 'Backorder Item',
+            'price' => 200.00,
+            'stock' => 0,
+            'status' => 'back_order',
+            'visible' => true,
+        ]);
+
+        $this->actingAs($user);
+
+        // Add standard item to cart
+        $this->postJson('/cart/add', ['item_id' => $standardItem->id, 'quantity' => 2]);
+
+        // Add backorder item to cart
+        $this->postJson('/cart/add', ['item_id' => $backorderItem->id, 'quantity' => 1]);
+
+        // Checkout with mixed items
+        $checkoutData = [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'address_line' => '123 Test St',
+            'city' => 'Test City',
+            'postal_code' => '12345',
+            'province' => 'Test Province',
+            'phone_number' => '09171234567',
+            'payment_method' => 'Bank',
+        ];
+
+        $response = $this->post('/checkout', $checkoutData);
+        $response->assertSessionHasNoErrors();
+
+        // Verify parent order was created
+        $parentOrder = Order::where('user_id', $user->id)
+            ->where('order_type', 'mixed')
+            ->first();
+
+        $this->assertNotNull($parentOrder, 'Parent order should be created for mixed checkout');
+        $this->assertNull($parentOrder->parent_order_id, 'Parent order should have no parent_order_id');
+
+        // Verify child orders were created
+        $standardOrder = Order::where('parent_order_id', $parentOrder->id)
+            ->where('order_type', 'standard')
+            ->first();
+
+        $backorderOrder = Order::where('parent_order_id', $parentOrder->id)
+            ->where('order_type', 'backorder')
+            ->first();
+
+        $this->assertNotNull($standardOrder, 'Standard sub-order should be created');
+        $this->assertNotNull($backorderOrder, 'Backorder sub-order should be created');
+
+        // Verify items were split correctly
+        $stdItems = $standardOrder->items()->get();
+        $boItems = $backorderOrder->items()->get();
+
+        $this->assertCount(1, $stdItems, 'Standard order should have 1 item type');
+        $this->assertCount(1, $boItems, 'Backorder order should have 1 item type');
+
+        $stdItem = $stdItems->first();
+        $boItem = $boItems->first();
+
+        $this->assertEquals($standardItem->id, $stdItem->item_id);
+        $this->assertEquals(2, $stdItem->quantity);
+        $this->assertFalse($stdItem->is_backorder);
+
+        $this->assertEquals($backorderItem->id, $boItem->item_id);
+        $this->assertEquals(1, $boItem->quantity);
+        $this->assertTrue($boItem->is_backorder);
+    }
+
+    /**
+     * Test payment calculation for mixed orders (100% standard + 50% backorder)
+     * @test
+     */
+    public function mixed_order_payment_calculation_correct()
+    {
+        $user = User::factory()->create();
+
+        $standardItem = Item::create([
+            'name' => 'Standard Item',
+            'price' => 100.00,
+            'stock' => 5,
+            'status' => 'in_stock',
+            'visible' => true,
+        ]);
+
+        $backorderItem = Item::create([
+            'name' => 'Backorder Item',
+            'price' => 200.00,
+            'stock' => 0,
+            'status' => 'back_order',
+            'visible' => true,
+        ]);
+
+        $this->actingAs($user);
+
+        // Add items
+        $this->postJson('/cart/add', ['item_id' => $standardItem->id, 'quantity' => 2]);
+        $this->postJson('/cart/add', ['item_id' => $backorderItem->id, 'quantity' => 1]);
+
+        // Get checkout page to verify payment calculation
+        $response = $this->get('/checkout');
+        $response->assertOk();
+        $response->assertViewHas('requiredPaymentAmount');
+
+        // Standard total: 100 * 2 = 200
+        // Backorder total: 200 * 1 = 200
+        // Required payment: 200 + (200 * 0.5) = 300
+
+        $requiredAmount = $response->viewData('requiredPaymentAmount');
+        $this->assertEquals(300.00, $requiredAmount, 'Required payment should be 100% of standard + 50% of backorder');
+    }
+
+    /**
+     * Test parent order shows correct totals
+     * @test
+     */
+    public function parent_order_aggregates_child_order_totals()
+    {
+        $user = User::factory()->create();
+
+        $standardItem = Item::create([
+            'name' => 'Standard Item',
+            'price' => 100.00,
+            'stock' => 5,
+            'status' => 'in_stock',
+            'visible' => true,
+        ]);
+
+        $backorderItem = Item::create([
+            'name' => 'Backorder Item',
+            'price' => 200.00,
+            'stock' => 0,
+            'status' => 'back_order',
+            'visible' => true,
+        ]);
+
+        $this->actingAs($user);
+
+        $this->postJson('/cart/add', ['item_id' => $standardItem->id, 'quantity' => 2]);
+        $this->postJson('/cart/add', ['item_id' => $backorderItem->id, 'quantity' => 1]);
+
+        $checkoutData = [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'address_line' => '123 Test St',
+            'city' => 'Test City',
+            'postal_code' => '12345',
+            'province' => 'Test Province',
+            'phone_number' => '09171234567',
+            'payment_method' => 'Bank',
+        ];
+
+        $this->post('/checkout', $checkoutData);
+
+        $parentOrder = Order::where('order_type', 'mixed')->first();
+
+        // Parent total = 200 (standard) + 200 (backorder) = 400
+        $this->assertEquals(400.00, $parentOrder->total_amount);
+
+        // Required payment = 200 + 100 = 300
+        $this->assertEquals(300.00, $parentOrder->required_payment_amount);
+
+        // Remaining balance = 100 (50% of backorder)
+        $this->assertEquals(100.00, $parentOrder->remaining_balance);
+    }
+
+    /**
+     * Test child orders have correct payment amounts
+     * @test
+     */
+    public function child_orders_have_correct_payment_requirements()
+    {
+        $user = User::factory()->create();
+
+        $standardItem = Item::create([
+            'name' => 'Standard Item',
+            'price' => 150.00,
+            'stock' => 10,
+            'status' => 'in_stock',
+            'visible' => true,
+        ]);
+
+        $backorderItem = Item::create([
+            'name' => 'Backorder Item',
+            'price' => 100.00,
+            'stock' => 0,
+            'status' => 'back_order',
+            'visible' => true,
+        ]);
+
+        $this->actingAs($user);
+
+        $this->postJson('/cart/add', ['item_id' => $standardItem->id, 'quantity' => 2]);
+        $this->postJson('/cart/add', ['item_id' => $backorderItem->id, 'quantity' => 3]);
+
+        $checkoutData = [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'address_line' => '123 Test St',
+            'city' => 'Test City',
+            'postal_code' => '12345',
+            'province' => 'Test Province',
+            'phone_number' => '09171234567',
+            'payment_method' => 'Bank',
+        ];
+
+        $this->post('/checkout', $checkoutData);
+
+        $parentOrder = Order::where('order_type', 'mixed')->first();
+        $standardOrder = $parentOrder->childOrders()->where('order_type', 'standard')->first();
+        $backorderOrder = $parentOrder->childOrders()->where('order_type', 'backorder')->first();
+
+        // Standard order: total = 150 * 2 = 300, required = 300 (100%)
+        $this->assertEquals(300.00, $standardOrder->total_amount);
+        $this->assertEquals(300.00, $standardOrder->required_payment_amount);
+        $this->assertEquals(0.00, $standardOrder->remaining_balance);
+
+        // Backorder order: total = 100 * 3 = 300, required = 150 (50%)
+        $this->assertEquals(300.00, $backorderOrder->total_amount);
+        $this->assertEquals(150.00, $backorderOrder->required_payment_amount);
+        $this->assertEquals(150.00, $backorderOrder->remaining_balance);
+    }
+
+    /**
+     * Test customer can view parent order with child orders listed
+     * @test
+     */
+    public function customer_views_parent_order_with_child_orders()
+    {
+        $user = User::factory()->create();
+
+        $standardItem = Item::create([
+            'name' => 'Standard Item',
+            'price' => 100.00,
+            'stock' => 5,
+            'status' => 'in_stock',
+            'visible' => true,
+        ]);
+
+        $backorderItem = Item::create([
+            'name' => 'Backorder Item',
+            'price' => 200.00,
+            'stock' => 0,
+            'status' => 'back_order',
+            'visible' => true,
+        ]);
+
+        $this->actingAs($user);
+
+        $this->postJson('/cart/add', ['item_id' => $standardItem->id, 'quantity' => 2]);
+        $this->postJson('/cart/add', ['item_id' => $backorderItem->id, 'quantity' => 1]);
+
+        $checkoutData = [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'address_line' => '123 Test St',
+            'city' => 'Test City',
+            'postal_code' => '12345',
+            'province' => 'Test Province',
+            'phone_number' => '09171234567',
+            'payment_method' => 'Bank',
+        ];
+
+        $this->post('/checkout', $checkoutData);
+
+        $parentOrder = Order::where('order_type', 'mixed')->first();
+
+        // View parent order details
+        $response = $this->get(route('customer.orders.show', $parentOrder->id));
+        $response->assertOk();
+        $response->assertViewHas('order', $parentOrder);
+
+        // Check that child orders are loaded
+        $viewOrder = $response->viewData('order');
+        $this->assertCount(2, $viewOrder->childOrders);
+    }
+
+    /**
+     * Test employee sees parent order with sub-orders in list
+     * @test
+     */
+    public function employee_sees_mixed_order_with_sub_orders_in_list()
+    {
+        $user = User::factory()->create();
+        $employee = User::factory()->create(['role' => 'employee']);
+
+        $standardItem = Item::create([
+            'name' => 'Standard Item',
+            'price' => 100.00,
+            'stock' => 5,
+            'status' => 'in_stock',
+            'visible' => true,
+        ]);
+
+        $backorderItem = Item::create([
+            'name' => 'Backorder Item',
+            'price' => 200.00,
+            'stock' => 0,
+            'status' => 'back_order',
+            'visible' => true,
+        ]);
+
+        $this->actingAs($user);
+
+        $this->postJson('/cart/add', ['item_id' => $standardItem->id, 'quantity' => 2]);
+        $this->postJson('/cart/add', ['item_id' => $backorderItem->id, 'quantity' => 1]);
+
+        $checkoutData = [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'address_line' => '123 Test St',
+            'city' => 'Test City',
+            'postal_code' => '12345',
+            'province' => 'Test Province',
+            'phone_number' => '09171234567',
+            'payment_method' => 'Bank',
+        ];
+
+        $this->post('/checkout', $checkoutData);
+
+        // View as employee
+        $this->actingAs($employee);
+        $response = $this->get('/employee/orders');
+        $response->assertOk();
+
+        $orders = $response->viewData('orders');
+        $parentOrder = $orders->first(fn($o) => $o->order_type === 'mixed');
+
+        $this->assertNotNull($parentOrder, 'Parent mixed order should be visible in employee list');
+        $this->assertCount(2, $parentOrder->childOrders, 'Child orders should be loaded');
+    }
+
+    /**
+     * Test partial stock fulfillment creates both standard and backorder items in correct order
+     * @test
+     */
+    public function partial_stock_item_splits_to_standard_and_backorder()
+    {
+        $user = User::factory()->create();
+
+        // Item with only partial stock
+        $item = Item::create([
+            'name' => 'Partial Stock Item',
+            'price' => 100.00,
+            'stock' => 2,
+            'status' => 'in_stock',
+            'visible' => true,
+        ]);
+
+        // Backorder item
+        $backorderItem = Item::create([
+            'name' => 'Pure Backorder Item',
+            'price' => 200.00,
+            'stock' => 0,
+            'status' => 'back_order',
+            'visible' => true,
+        ]);
+
+        $this->actingAs($user);
+
+        // Add 5 qty of partial stock item (only 2 in stock)
+        $this->postJson('/cart/add', ['item_id' => $item->id, 'quantity' => 5]);
+
+        // Add backorder item
+        $this->postJson('/cart/add', ['item_id' => $backorderItem->id, 'quantity' => 1]);
+
+        $checkoutData = [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'address_line' => '123 Test St',
+            'city' => 'Test City',
+            'postal_code' => '12345',
+            'province' => 'Test Province',
+            'phone_number' => '09171234567',
+            'payment_method' => 'Bank',
+        ];
+
+        $this->post('/checkout', $checkoutData);
+
+        $parentOrder = Order::where('order_type', 'mixed')->first();
+        $standardOrder = $parentOrder->childOrders()->where('order_type', 'standard')->first();
+        $backorderOrder = $parentOrder->childOrders()->where('order_type', 'backorder')->first();
+
+        // Standard order should have the pure backorder item only
+        // (since partial stock item is handled separately)
+        $stdItems = $standardOrder->items()->get();
+        $this->assertGreaterThan(0, $stdItems->count(), 'Standard order should have items');
+
+        // Backorder order should have pure backorder item and partial stock remainder
+        $boItems = $backorderOrder->items()->get();
+        $this->assertGreaterThan(0, $boItems->count(), 'Backorder order should have items');
+        
+        // Total items across both orders should account for all quantities
+        $totalQty = $stdItems->sum('quantity') + $boItems->sum('quantity');
+        $this->assertEquals(6, $totalQty, 'Total quantity should be 5 (partial item) + 1 (backorder item)');
+    }
+
+    /**
+     * Test that backorder order payment is only 50% of total
+     * @test
+     */
+    public function backorder_order_requires_50_percent_payment()
+    {
+        $user = User::factory()->create();
+
+        // Create backorder item (out of stock)
+        $backorderItem = Item::create([
+            'name' => 'Backorder Item',
+            'price' => 1000.00,
+            'stock' => 0,
+            'status' => 'back_order',
+            'visible' => true,
+        ]);
+
+        $this->actingAs($user);
+
+        // Add only backorder item to cart
+        $this->postJson('/cart/add', ['item_id' => $backorderItem->id, 'quantity' => 1]);
+
+        $checkoutData = [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'address_line' => '123 Test St',
+            'city' => 'Test City',
+            'postal_code' => '12345',
+            'province' => 'Test Province',
+            'phone_number' => '09171234567',
+            'payment_method' => 'GCash',
+        ];
+
+        $response = $this->post('/checkout', $checkoutData);
+        $response->assertRedirect();
+
+        // Find the backorder order
+        $order = Order::where('order_type', 'backorder')->first();
+        $this->assertNotNull($order);
+        
+        $this->assertEquals(1000.00, $order->total_amount, 'Total amount should be 1000');
+        $this->assertEquals(500.00, $order->required_payment_amount, 'Required payment should be 50% = 500');
+        
+        // Try to pay less than required - should fail
+        $paymentResponse = $this->postJson('/payments/gcash', [
+            'order_id' => $order->id,
+            'amount' => 400.00,
+            'reference' => 'TEST123',
+        ]);
+        $paymentResponse->assertStatus(422);
+        $paymentResponse->assertJsonFragment(['success' => false]);
+        
+        // Pay exactly the required 50%
+        $paymentResponse = $this->postJson('/payments/gcash', [
+            'order_id' => $order->id,
+            'amount' => 500.00,
+            'reference' => 'TEST123',
+        ]);
+        $paymentResponse->assertStatus(200);
+        $paymentResponse->assertJsonFragment(['success' => true]);
+        
+        // Refresh and check payment status
+        $order->refresh();
+        $this->assertEquals('partially_paid', $order->payment_status, 'Payment status should be partially_paid');
+        $this->assertEquals(500.00, $order->remaining_balance, 'Remaining balance should be 500 (the other 50%)');
+    }
+
+    /**
+     * Test that custom order payment is only 50% of total
+     * @test
+     */
+    public function custom_order_requires_50_percent_payment()
+    {
+        $user = User::factory()->create();
+
+        // Create a custom order manually
+        $order = Order::create([
+            'user_id' => $user->id,
+            'order_type' => 'custom',
+            'status' => 'pending',
+            'total_amount' => 2000.00,
+            'payment_status' => 'unpaid',
+        ]);
+
+        // Set required payment amount
+        $order->required_payment_amount = $order->calculateRequiredPaymentAmount();
+        $order->save();
+
+        $this->actingAs($user);
+        
+        $this->assertEquals(2000.00, $order->total_amount);
+        $this->assertEquals(1000.00, $order->required_payment_amount, 'Required payment should be 50% = 1000');
+        
+        // Try to pay less than required - should fail
+        $paymentResponse = $this->postJson('/payments/gcash', [
+            'order_id' => $order->id,
+            'amount' => 900.00,
+            'reference' => 'TEST456',
+        ]);
+        $paymentResponse->assertStatus(422);
+        
+        // Pay exactly the required 50%
+        $paymentResponse = $this->postJson('/payments/gcash', [
+            'order_id' => $order->id,
+            'amount' => 1000.00,
+            'reference' => 'TEST456',
+        ]);
+        $paymentResponse->assertStatus(200);
+        $paymentResponse->assertJsonFragment(['success' => true]);
+        
+        // Refresh and check payment status
+        $order->refresh();
+        $this->assertEquals('partially_paid', $order->payment_status);
+        $this->assertEquals(1000.00, $order->remaining_balance, 'Remaining balance should be 1000 (the other 50%)');
+    }
+
+    /**
+     * Test that standard order payment requires 100%
+     * @test
+     */
+    public function standard_order_requires_100_percent_payment()
+    {
+        $user = User::factory()->create();
+
+        // Create standard item with stock
+        $standardItem = Item::create([
+            'name' => 'Standard Item',
+            'price' => 1000.00,
+            'stock' => 5,
+            'status' => 'in_stock',
+            'visible' => true,
+        ]);
+
+        $this->actingAs($user);
+
+        // Add only standard item to cart
+        $this->postJson('/cart/add', ['item_id' => $standardItem->id, 'quantity' => 1]);
+
+        $checkoutData = [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'address_line' => '123 Test St',
+            'city' => 'Test City',
+            'postal_code' => '12345',
+            'province' => 'Test Province',
+            'phone_number' => '09171234567',
+            'payment_method' => 'GCash',
+        ];
+
+        $response = $this->post('/checkout', $checkoutData);
+        $response->assertRedirect();
+
+        // Find the standard order
+        $order = Order::where('order_type', 'standard')->first();
+        $this->assertNotNull($order);
+        
+        $this->assertEquals(1000.00, $order->total_amount);
+        $this->assertEquals(1000.00, $order->required_payment_amount, 'Required payment should be 100%');
+        
+        // Try to pay less - should fail
+        $paymentResponse = $this->postJson('/payments/gcash', [
+            'order_id' => $order->id,
+            'amount' => 500.00,
+            'reference' => 'TEST789',
+        ]);
+        $paymentResponse->assertStatus(422);
+        
+        // Pay the full amount
+        $paymentResponse = $this->postJson('/payments/gcash', [
+            'order_id' => $order->id,
+            'amount' => 1000.00,
+            'reference' => 'TEST789',
+        ]);
+        $paymentResponse->assertStatus(200);
+        $paymentResponse->assertJsonFragment(['success' => true]);
+        
+        // Refresh and check payment status
+        $order->refresh();
+        $this->assertEquals('paid', $order->payment_status, 'Payment status should be paid');
+        $this->assertEquals(0, $order->remaining_balance, 'Remaining balance should be 0');
+    }
+}


### PR DESCRIPTION
- Add payment_tracking columns to orders table (required_payment_amount, remaining_balance)
- Add parent_order_id foreign key for order hierarchy
- Update payment_status enum to include 'partially_paid'
- Add 'mixed' to order_type enum for split orders
- Implement MixedOrderSplitTest with comprehensive test scenarios
- Update Order model with parent-child relationships and payment calculation logic
- Update controllers to handle mixed order creation and payment processing
- Update views to display mixed order information and payment requirements
- Add support for 50% payment on backorder and custom orders, 100% on standard